### PR TITLE
chore(readme): Remove extra developer configuration steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # PoE Overlay (Community Fork)
 
-PoE Overlay is a tool for Path of Exile. The ***core aspect*** is to blend in with the game. Built with Electron and Angular.
+PoE Overlay is a tool for Path of Exile. The **_core aspect_** is to blend in with the game. Built with Electron and Angular.
 
 <!-- TOC -->
+
 - [Community Development](#community-development)
 - [Features](#features)
 - [Roadmap](#roadmap)
@@ -28,36 +29,38 @@ In order to avoid version confusion with the official version, we should do the 
 
 [![Feature Overview As Video](img/video.jpg)](https://www.youtube.com/watch?v=_cJmW8QkQnM)
 
-* Evaluation of items:
-    * select your preferred currencies and language
-    * uses the official pathofexile.com/trade website
-    * a graphical display of the price distribution<br><details>![item](img/item_0.5.8.jpg)</details>
-    * filter your search on all supported properties on click<br> <details>![item_filter](img/item_filter_0.5.8.jpg)</details>
-    * an in game browser to display the created search<br> <details>![browser](img/item_browser_0.5.8.jpg)</details>
-    * lets you price tag the item by clicking the desired bar/value
+- Evaluation of items:
 
-* Customisable keybindings:  
-    * bind in game commands to a custom hotkey
-    * premade /hideout on `F5` and /dnd on `F6`
-    
-* Bookmark
-    * bind websites on hotkeys
+  - select your preferred currencies and language
+  - uses the official pathofexile.com/trade website
+  - a graphical display of the price distribution<br><details>![item](img/item_0.5.8.jpg)</details>
+  - filter your search on all supported properties on click<br> <details>![item_filter](img/item_filter_0.5.8.jpg)</details>
+  - an in game browser to display the created search<br> <details>![browser](img/item_browser_0.5.8.jpg)</details>
+  - lets you price tag the item by clicking the desired bar/value
 
-* Misc:
-    * Navigating storage by CTRL + WHEEL
-    * Highlighting items by ALT + F
+- Customisable keybindings:
+  - bind in game commands to a custom hotkey
+  - premade /hideout on `F5` and /dnd on `F6`
+- Bookmark
 
-* Menu:
-    * an in game menu to change all settings<br> <details>![menu](img/menu_0.5.2.jpg)</details>
-    
+  - bind websites on hotkeys
+
+- Misc:
+
+  - Navigating storage by CTRL + WHEEL
+  - Highlighting items by ALT + F
+
+- Menu:
+  - an in game menu to change all settings<br> <details>![menu](img/menu_0.5.2.jpg)</details>
+
 See the [Wiki](https://github.com/PoE-Overlay-Community/PoE-Overlay-Community-Fork/wiki) for further details.
 
 ## Roadmap
 
-| Module        | Status        | Notes   |
-| ------------- |-------------: | ------- |
-| Linux         | 50%           | - Allow running this app on Linux
-| Trade         | 0%            | - Send messages<br>- Trade UI<br>- etc.
+| Module | Status | Notes                                   |
+| ------ | -----: | --------------------------------------- |
+| Linux  |    50% | - Allow running this app on Linux       |
+| Trade  |     0% | - Send messages<br>- Trade UI<br>- etc. |
 
 ## Enduser
 
@@ -67,21 +70,21 @@ These instructions will set you up to run and enjoy the overlay.
 
 #### Supports
 
-* Windows 10 x64
-* Windows 7 x64 (with keyboard support enabled)
-* Linux coming soon (can be compiled manually)
+- Windows 10 x64
+- Windows 7 x64 (with keyboard support enabled)
+- Linux coming soon (can be compiled manually)
 
 #### Prerequisites
 
-* Path of Exile ***must be*** in windowed fullscreen mode
-* PoE Overlay ***should run*** with privileged rights
-* You ***may need*** to install [vc_redist](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) 
+- Path of Exile **_must be_** in windowed fullscreen mode
+- PoE Overlay **_should run_** with privileged rights
+- You **_may need_** to install [vc_redist](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
 
 #### Installing
 
 1. Head over to [Releases](https://github.com/PoE-Overlay-Community/PoE-Overlay-Community-Fork/releases) and download one of the following files
-    1. `poe-overlay-Setup-0.6.28.exe` to install locally. This supports auto update/ auto launch.
-    2. `poe-overlay-0.6.28.exe` portable version. This does not support auto update/ auto launch.
+   1. `poe-overlay-Setup-0.6.28.exe` to install locally. This supports auto update/ auto launch.
+   2. `poe-overlay-0.6.28.exe` portable version. This does not support auto update/ auto launch.
 2. Run either of your downloaded file
 3. Start Path of Exile
 4. Wait until you can see `PoE Overlay 0.6.28` in the bottom left corner
@@ -91,10 +94,10 @@ These instructions will set you up to run and enjoy the overlay.
 
 You can change these shortcuts in the user settings menu.
 
-|Shortcut        |Description
-|---             |---	    
-| `ctrl+d`       | Displays the item in a frame and evaluates the price. You can open the offical trade site on click of the currency value
-| `f7`           | Opens the user settings menu
+| Shortcut | Description                                                                                                              |
+| -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `ctrl+d` | Displays the item in a frame and evaluates the price. You can open the offical trade site on click of the currency value |
+| `f7`     | Opens the user settings menu                                                                                             |
 
 Full list below. Click on `Details`.
 
@@ -142,12 +145,13 @@ npm install --global --production windows-build-tools
 
 #### Installing
 
-1. Clone the repository. 
+1. Clone the repository.
 2. Open up the folder with your editor.
-3. Run ```npm install``` to install all required npm packages.
-4. Run ```npm run electron:rebuild``` to generate a executable [robotjs](https://github.com/octalmage/robotjs) version.
+3. Run `npm install` to install all required npm packages.
+4. Run `npm run electron:rebuild` to generate a executable [robotjs](https://github.com/octalmage/robotjs) version.
 
 That's it. Your Project should now be ready to run:
+
 ```
 npm run start
 ```
@@ -155,6 +159,7 @@ npm run start
 ### Running the tests
 
 These are used to test for eg. the external APIs (poe.ninja, etc.). To run those:
+
 ```
 npm run ng:test
 ```
@@ -170,6 +175,7 @@ npm run ng:lint
 ### Building
 
 A electron executable can be generate by calling:
+
 ```
 npm run electron:windows
 # Under the hood:
@@ -180,8 +186,8 @@ npm run electron:windows
 
 ### Built With
 
-* [Electron](https://electronjs.org/) - The desktop app framework
-* [Angular](https://angular.io/) - A component framework
+- [Electron](https://electronjs.org/) - The desktop app framework
+- [Angular](https://angular.io/) - A component framework
 
 ### Contributing
 
@@ -189,11 +195,11 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 
 ### Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/PoE-Overlay-Community/PoE-Overlay-Community-Fork/tags). 
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/PoE-Overlay-Community/PoE-Overlay-Community-Fork/tags).
 
 ## Authors
 
-* **Nicklas Ronge** - *Initial work* - [Kyusung4698](https://github.com/Kyusung4698)
+- **Nicklas Ronge** - _Initial work_ - [Kyusung4698](https://github.com/Kyusung4698)
 
 See also the list of [contributors](https://github.com/PoE-Overlay-Community/PoE-Overlay-Community-Fork/contributors) who participated in this project.
 
@@ -203,7 +209,7 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md
 
 ## Acknowledgments
 
-* [Grinding Gear Games](https://www.pathofexile.com/) the game
-* [PoE TradeMacro](https://github.com/PoE-TradeMacro/POE-TradeMacro) initial inspiration
-* [poe.ninja](https://poe.ninja/) currency values
-* [libggpk](https://github.com/MuxaJIbI4/libggpk) parsing content.ggpk
+- [Grinding Gear Games](https://www.pathofexile.com/) the game
+- [PoE TradeMacro](https://github.com/PoE-TradeMacro/POE-TradeMacro) initial inspiration
+- [poe.ninja](https://poe.ninja/) currency values
+- [libggpk](https://github.com/MuxaJIbI4/libggpk) parsing content.ggpk

--- a/README.md
+++ b/README.md
@@ -135,18 +135,9 @@ Your editor of choice for a node project - like [vscode](https://code.visualstud
 The first thing to install is [nodejs](https://nodejs.org/en/). Download your matching executable and follow the instructions.
 
 Then you need to install the [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) from an elevated PowerShell or CMD.exe. This may take a while (10-15min).
+
 ```
 npm install --global --production windows-build-tools
-```
-
-A TypeScript compiler:
-```
-npm install -g typescript
-```
-
-And the Angular CLI:
-```
-npm install -g @angular/cli
 ```
 
 #### Installing

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "npm run electron:serve-tsc && ng build",
     "build:dev": "npm run build",
     "build:prod": "npm run build -- -c production",
-    "electron:serve-tsc": "tsc -p tsconfig.serve.json",
+    "electron:serve-tsc": "node_modules/.bin/tsc -p tsconfig.serve.json",
     "electron:serve": "wait-on http-get://localhost:4200/ && npm run electron:serve-tsc && electron . --serve",
     "electron:local": "npm run build:prod && electron .",
     "electron:windows": "npm run build:prod && electron-builder build --windows",


### PR DESCRIPTION
README Changes:
1. Prettier on README.md
2. Removed extra dev steps

Script Changes:
1. Use node_modules type script.

The only npm global required is 

```
PS > npm list -g --depth=0
C:\Users\meril\AppData\Roaming\npm
`-- windows-build-tools@5.2.2
```