### PR TITLE
Allow canceling of Shortcut Mapping

### DIFF
--- a/src/app/modules/bookmark/component/bookmark-settings/bookmark-settings.component.html
+++ b/src/app/modules/bookmark/component/bookmark-settings/bookmark-settings.component.html
@@ -26,10 +26,7 @@
         </mat-card>
     </div>
     <div class="col-md-6">
-        <mat-card>
-            <div align="center">
-                <button mat-button (click)="onAddClick()">{{'bookmark.add' | translate}}</button>
-            </div>
-        </mat-card>
+        <button mat-raised-button (click)="onAddClick()"
+            class="card-button">{{'bookmark.add' | translate}}</button>
     </div>
 </div>

--- a/src/app/modules/bookmark/component/bookmark-settings/bookmark-settings.component.scss
+++ b/src/app/modules/bookmark/component/bookmark-settings/bookmark-settings.component.scss
@@ -8,3 +8,8 @@
     z-index: 1;
   }
 }
+
+.card-button {
+  padding: 16px;
+  width: 100%;
+}

--- a/src/app/shared/module/material/component/accelerator/accelerator.component.html
+++ b/src/app/shared/module/material/component/accelerator/accelerator.component.html
@@ -1,7 +1,12 @@
 <mat-form-field>
     <mat-label>{{label}}</mat-label>
     <input matInput [value]="(value || 'material.accelerator.unbound') | translate" [disabled]="!recording" (keydown)="onKeydown($event)" #input>
-    <button matSuffix mat-button (click)="onKeyboardClick(input)">
+    <button matSuffix mat-button (click)="onKeyboardClick(input)" title="Set Shortcut" *ngIf="!recording; else cancel">
         <mat-icon> keyboard </mat-icon>
     </button>
+    <ng-template #cancel>
+        <button matSuffix mat-button (click)="cancelSetShortcut()" title="Cancel Setting Shortcut">
+            <mat-icon> clear </mat-icon>
+        </button>
+    </ng-template>
 </mat-form-field>

--- a/src/app/shared/module/material/component/accelerator/accelerator.component.ts
+++ b/src/app/shared/module/material/component/accelerator/accelerator.component.ts
@@ -26,11 +26,18 @@ export class AcceleratorComponent {
   public valueChange = new EventEmitter<string>();
 
   public recording = false;
+  valueBackup: string;
 
   public onKeyboardClick(el: HTMLElement): void {
     this.recording = true;
     el.focus();
+    this.valueBackup = this.value;
     this.value = 'material.accelerator.any';
+  }
+
+  public cancelSetShortcut() {
+    this.recording = false;
+    this.value = this.valueBackup;
   }
 
   public onKeydown(event: KeyboardEvent): void {


### PR DESCRIPTION
When you click the 'keyboard' icon to begin mapping a shortcut there was no way to stop this process. I have replaced the keyboard icon with the clear/remove icon to allow the user to cancel the keyboard mapping, putting it back to what it was before.

As well, the 'add bookmark' button clickable area was wildly misleading, and has been changed to represent the same physical area as before but be entirely clickable.