### PR TITLE
Adds Linux builder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
             "when": "$(basename).ts"
         },
         "**/*.js.map": true,
-        "release": true,
         "dist": true
     }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# Dockerfile for Linux build automation. Run with 'docker build -o release .'
+# Demonstrates developing PoE-Overlay on Linux and produces testable Linux builds.
+# Build and run with 'docker build .' from repo root. Each step will be cached
+# independently, so subsequent builds will be faster.
+# IMPORTANT: Set DOCKER_BUILDKIT=1 in your environment variables or you will not
+# get any build artifacts in your release folder.
+# First build will take up to 10 minutes.
+ARG codedir=/opt/PoE-Overlay-Community-Fork
+
+# Since the Electron builder targets Debian packaging, start with an Ubuntu LTS image.
+FROM ubuntu:20.04 AS build-stage
+
+# Install build environment dependencies.
+RUN apt-get update
+RUN apt-get install -y libx11-dev libxtst-dev libpng-dev wget make g++ git lsb-release gnupg
+# https://github.com/nodesource/distributions/blob/0d3d988/README.md#installation-instructions
+RUN wget https://deb.nodesource.com/setup_12.x -O nodesource.sh
+RUN bash nodesource.sh
+RUN apt-get install -y nodejs
+
+# Set up working directory.
+ARG codedir
+RUN mkdir $codedir
+WORKDIR $codedir
+
+# Copy the code into the container, avoiding .git and node_modules.
+COPY *.json $codedir/
+COPY browserslist $codedir
+COPY dev-app-update.yml $codedir
+COPY main.ts $codedir
+COPY overlay.babel #codedir
+COPY electron $codedir/electron
+COPY img $codedir/img
+COPY src $codedir/src
+
+# Install NodeJS dependencies/modules.
+RUN npm install
+
+# Build the app.
+# If you get an out of memory error, increase Docker's resources.
+RUN mkdir -p $codedir/release 
+RUN echo 'hi' > $codedir/release/test
+RUN ls $codedir/release
+RUN npm run electron:linux
+
+# Export the build from the container to the 'release' folder on your PC.
+FROM scratch as export-stage
+ARG codedir
+COPY --from=build-stage $codedir/release/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,7 @@ RUN npm install
 
 # Build the app.
 # If you get an out of memory error, increase Docker's resources.
-RUN mkdir -p $codedir/release 
-RUN echo 'hi' > $codedir/release/test
-RUN ls $codedir/release
+RUN mkdir -p $codedir/release
 RUN npm run electron:linux
 
 # Export the build from the container to the 'release' folder on your PC.

--- a/angular.json
+++ b/angular.json
@@ -57,8 +57,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "10mb",
-                  "maximumError": "20mb"
+                  "maximumWarning": "32mb",
+                  "maximumError": "64mb"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -30,7 +30,7 @@
         ]
     },
     "linux": {
-        "icon": "dist/favicon.png",
+        "icon": "dist/favicon@4x.png",
         "target": [
             "deb",
             "AppImage"


### PR DESCRIPTION
This will generate 64-bit Linux builds (DEB package and AppImage) and put them in the `release` directory.

- Unhides the `release` directory in VSCode. 
- Increases Angular memory budget
- Scales up Favicon to meet 256x256 minimum size  
  
To use this:

1. Install Docker
2. Open the repo in VSCode
3. Run `docker build -o release .` in a VSCode terminal window