### PR TITLE
Indistinguisable Modifiers Bugfix

### DIFF
--- a/src/app/data/poe/schema/trade.ts
+++ b/src/app/data/poe/schema/trade.ts
@@ -131,6 +131,8 @@ export interface StatsFilter {
 
 export interface StatsGroup {
   type?: string
+  min?: number
+  max?: number
   filters?: StatsFilter[]
 }
 

--- a/src/app/shared/module/poe/provider/stats-indistinguishable.provider.ts
+++ b/src/app/shared/module/poe/provider/stats-indistinguishable.provider.ts
@@ -1,15 +1,5 @@
 import { Injectable } from '@angular/core'
-import {
-  crafted,
-  delve,
-  enchant,
-  explicit,
-  fractured,
-  implicit,
-  monster,
-  pseudo,
-  veiled,
-} from '../../../../../assets/poe/stats-indistinguishable.json'
+import { indistinguishableStats } from '../../../../../assets/poe/stats-indistinguishable.json'
 import { StatIndistinguishableMap, StatType } from '../type'
 
 @Injectable({
@@ -17,25 +7,6 @@ import { StatIndistinguishableMap, StatType } from '../type'
 })
 export class StatsIndistinguishableProvider {
   public provide(group: StatType): StatIndistinguishableMap {
-    switch (group) {
-      case StatType.Pseudo:
-        return pseudo
-      case StatType.Explicit:
-        return explicit
-      case StatType.Implicit:
-        return implicit
-      case StatType.Crafted:
-        return crafted
-      case StatType.Fractured:
-        return fractured
-      case StatType.Enchant:
-        return enchant
-      case StatType.Veiled:
-        return veiled
-      case StatType.Monster:
-        return monster
-      case StatType.Delve:
-        return delve
-    }
+    return indistinguishableStats[group]
   }
 }

--- a/src/app/shared/module/poe/provider/stats-indistinguishable.provider.ts
+++ b/src/app/shared/module/poe/provider/stats-indistinguishable.provider.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core'
+import {
+  crafted,
+  delve,
+  enchant,
+  explicit,
+  fractured,
+  implicit,
+  monster,
+  pseudo,
+  veiled,
+} from '../../../../../assets/poe/stats-indistinguishable.json'
+import { StatIndistinguishableMap, StatType } from '../type'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class StatsIndistinguishableProvider {
+  public provide(group: StatType): StatIndistinguishableMap {
+    switch (group) {
+      case StatType.Pseudo:
+        return pseudo
+      case StatType.Explicit:
+        return explicit
+      case StatType.Implicit:
+        return implicit
+      case StatType.Crafted:
+        return crafted
+      case StatType.Fractured:
+        return fractured
+      case StatType.Enchant:
+        return enchant
+      case StatType.Veiled:
+        return veiled
+      case StatType.Monster:
+        return monster
+      case StatType.Delve:
+        return delve
+    }
+  }
+}

--- a/src/app/shared/module/poe/service/item/processor/item-pseudo-processor.service.ts
+++ b/src/app/shared/module/poe/service/item/processor/item-pseudo-processor.service.ts
@@ -58,6 +58,7 @@ export class ItemPseudoProcessorService {
         negated: false,
         option: false,
         mod: undefined,
+        indistinguishable: undefined
       }
       itemStats.push(itemStat)
       if (values.length > 0 && (!minCount || count >= minCount)) {

--- a/src/app/shared/module/poe/service/item/query/item-search-filters-stats.service.ts
+++ b/src/app/shared/module/poe/service/item/query/item-search-filters-stats.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core'
 import { Query, StatsFilter } from '@data/poe'
-import { Item, ItemSearchFiltersService, Language } from '@shared/module/poe/type'
+import { Item, ItemStat, ItemSearchFiltersService, Language } from '@shared/module/poe/type'
 
 @Injectable({
   providedIn: 'root',
@@ -12,69 +12,87 @@ export class ItemSearchFiltersStatsService implements ItemSearchFiltersService {
       return
     }
 
-    query.stats.push({
-      type: 'and',
-      filters: stats.map((stat) => {
-        const id = `${stat.type}.${stat.tradeId}`
-        const filter: StatsFilter = {
-          disabled: false,
-          id,
-        }
+    const mainStats = stats.filter((stat) => !stat.indistinguishable)
+    if (mainStats.length > 0) {
+      query.stats.push({
+        type: 'and',
+        filters: mainStats.map((stat) => this.mapStat(stat, stat.tradeId))
+      })
+    }
 
-        if (stat.option) {
-          filter.value = {
-            option: isNaN(+stat.predicate) ? stat.predicate : +stat.predicate,
-          }
-        } else {
-          const mins = stat.values.filter((x) => x.min !== undefined)
-          const maxs = stat.values.filter((x) => x.max !== undefined)
+    const indistinguishableStats = stats.filter((stat) => stat.indistinguishable);
+    for (const indistinguishableStat of indistinguishableStats) {
+      query.stats.push({
+        type: 'count',
+        min: 1,
+        max: 1,
+        filters: [
+          this.mapStat(indistinguishableStat, indistinguishableStat.tradeId),
+          this.mapStat(indistinguishableStat, indistinguishableStat.indistinguishable)
+        ]
+      })
+    }
+  }
 
-          if (mins.length === 0 && maxs.length === 0) {
-            return filter
-          }
+  private mapStat(stat: ItemStat, tradeId: string): StatsFilter {
+    const id = `${stat.type}.${tradeId}`
+    const filter: StatsFilter = {
+      disabled: false,
+      id,
+    }
 
-          const negate = !stat.negated && stat.predicate[0] === 'N' ? -1 : 1
+    if (stat.option) {
+      filter.value = {
+        option: isNaN(+stat.predicate) ? stat.predicate : +stat.predicate,
+      }
+    } else {
+      const mins = stat.values.filter((x) => x.min !== undefined)
+      const maxs = stat.values.filter((x) => x.max !== undefined)
 
-          let min: number
-          if (mins.length > 0) {
-            min = mins.reduce((a, b) => a + b.min, 0) / mins.length
-            min = Math.round(min * 10) / 10
-            min *= negate
-          }
-
-          let max: number
-          if (maxs.length > 0) {
-            max = maxs.reduce((a, b) => a + b.max, 0) / maxs.length
-            max = Math.round(max * 10) / 10
-            max *= negate
-          }
-
-          if (min !== undefined && max !== undefined) {
-            if (min > max) {
-              const tmp = min
-              min = max
-              max = tmp
-            }
-          } else if (min !== undefined) {
-            if (min >= 0 || !stat.negated) {
-              max = 99999
-            } else {
-              max = min
-              min = -99999
-            }
-          } else if (max !== undefined) {
-            if (max >= 0) {
-              min = 0
-            } else {
-              min = max
-              max = -1
-            }
-          }
-          filter.value = { min, max }
-        }
-
+      if (mins.length === 0 && maxs.length === 0) {
         return filter
-      }),
-    })
+      }
+
+      const negate = !stat.negated && stat.predicate[0] === 'N' ? -1 : 1
+
+      let min: number
+      if (mins.length > 0) {
+        min = mins.reduce((a, b) => a + b.min, 0) / mins.length
+        min = Math.round(min * 10) / 10
+        min *= negate
+      }
+
+      let max: number
+      if (maxs.length > 0) {
+        max = maxs.reduce((a, b) => a + b.max, 0) / maxs.length
+        max = Math.round(max * 10) / 10
+        max *= negate
+      }
+
+      if (min !== undefined && max !== undefined) {
+        if (min > max) {
+          const tmp = min
+          min = max
+          max = tmp
+        }
+      } else if (min !== undefined) {
+        if (min >= 0 || !stat.negated) {
+          max = 99999
+        } else {
+          max = min
+          min = -99999
+        }
+      } else if (max !== undefined) {
+        if (max >= 0) {
+          min = 0
+        } else {
+          min = max
+          max = -1
+        }
+      }
+      filter.value = { min, max }
+    }
+
+    return filter
   }
 }

--- a/src/app/shared/module/poe/service/stats/stats.service.ts
+++ b/src/app/shared/module/poe/service/stats/stats.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core'
 import { StatsLocalProvider } from '../../provider/stats-local.provider'
+import { StatsIndistinguishableProvider } from '../../provider/stats-indistinguishable.provider'
 import { StatsProvider } from '../../provider/stats.provider'
 import { ItemStat, Language, Stat, StatType } from '../../type'
 import { ContextService } from '../context.service'
@@ -50,7 +51,8 @@ export class StatsService {
   constructor(
     private readonly context: ContextService,
     private readonly statsProvider: StatsProvider,
-    private readonly statsLocalProvider: StatsLocalProvider
+    private readonly statsLocalProvider: StatsLocalProvider,
+    private readonly statsIndistinguishableProvider: StatsIndistinguishableProvider
   ) {}
 
   public translate(stat: Stat, predicate: string, language?: Language): string {
@@ -134,6 +136,7 @@ export class StatsService {
     for (const type of search.types) {
       const stats = this.statsProvider.provide(type)
       const locals = this.statsLocalProvider.provide(type)
+      const indistinguishables = this.statsIndistinguishableProvider.provide(type)
       for (const tradeId in stats) {
         if (!stats.hasOwnProperty(tradeId)) {
           continue
@@ -166,8 +169,10 @@ export class StatsService {
               return id.split(' ').join('').split('%').join('_').split('+').join('_')
             }
 
+            const indistinguishable = indistinguishables[tradeId]
+
             const localKey = getKey(stat.id || '')
-            if (locals[localKey]) {
+            if (locals[localKey] && !indistinguishable) {
               let optId = locals[localKey]
               if (stat.mod === 'local') {
                 // global to local optId
@@ -193,6 +198,7 @@ export class StatsService {
               type,
               tradeId,
               values: test.slice(1).map((x) => ({ text: x })),
+              indistinguishable
             }
             results.push({
               stat: itemStat,

--- a/src/app/shared/module/poe/type/content.type.ts
+++ b/src/app/shared/module/poe/type/content.type.ts
@@ -25,6 +25,10 @@ export interface StatLocalMap {
   [id: string]: string
 }
 
+export interface StatIndistinguishableMap {
+  [id: string]: string
+}
+
 export interface ModValue {
   min: number
   max: number

--- a/src/app/shared/module/poe/type/item.type.ts
+++ b/src/app/shared/module/poe/type/item.type.ts
@@ -172,6 +172,7 @@ export interface ItemStat {
   type: StatType
   values: ItemValue[]
   option: boolean
+  indistinguishable: string
 }
 
 export interface ItemRequirements {

--- a/src/assets/poe/stats-indistinguishable.json
+++ b/src/assets/poe/stats-indistinguishable.json
@@ -1,14 +1,16 @@
 {
-  "explicit": {
-    "stat_3885634897": "stat_795138349",
-    "stat_795138349": "stat_3885634897"
-  },
-  "implicit": { },
-  "crafted": {},
-  "fractured": {},
-  "enchant": {},
-  "pseudo": {},
-  "veiled": {},
-  "monster": {},
-  "delve": {}
+  "indistinguishableStats": {
+    "explicit": {
+      "stat_3885634897": "stat_795138349",
+      "stat_795138349": "stat_3885634897"
+    },
+    "implicit": {},
+    "crafted": {},
+    "fractured": {},
+    "enchant": {},
+    "pseudo": {},
+    "veiled": {},
+    "monster": {},
+    "delve": {}
+  }
 }

--- a/src/assets/poe/stats-indistinguishable.json
+++ b/src/assets/poe/stats-indistinguishable.json
@@ -1,0 +1,14 @@
+{
+  "explicit": {
+    "stat_3885634897": "stat_795138349",
+    "stat_795138349": "stat_3885634897"
+  },
+  "implicit": { },
+  "crafted": {},
+  "fractured": {},
+  "enchant": {},
+  "pseudo": {},
+  "veiled": {},
+  "monster": {},
+  "delve": {}
+}


### PR DESCRIPTION
## Description

This bugfix is intended to fix https://github.com/PoE-Overlay-Community/PoE-Overlay-Community-Fork/issues/8  
  
## Changes

* Added a stats-indistinguishable.json asset containing stats that are indistinguishable by their regex (defined in stats.json)
  * Currently only the "chance to Poison on Hit" stat from Issue 8 has been added
* Added a provider for the json data so it can be used throughout the codebase
* Updated the Stats service so it uses this data and adds it to the ItemStat
* Updated the Item Search Filter Stats service:
  * It now creates multiple stat groups in its search:
    * 1 main group containing all stats that are distinguishable
    * 0~N sub-groups using the "count min/max" search options, containing all indistinguishable stats

## Replication Steps

See details in https://github.com/PoE-Overlay-Community/PoE-Overlay-Community-Fork/issues/8  

## Screenshots/Video

Sample item searched, returning a single (my own) result:
![image](https://user-images.githubusercontent.com/4527188/84566909-447c5800-ad75-11ea-94d7-5bfb7e55a982.png)

With the indistinguishable poison on hit stat selected:
(This returns 0 results whithout this bugfix)
![image](https://user-images.githubusercontent.com/4527188/84566926-5b22af00-ad75-11ea-8cc5-09bd4ee5df39.png)

Actual search result:
https://www.pathofexile.com/trade/search/Delirium/545w8lmHa
![image](https://user-images.githubusercontent.com/4527188/84566965-a210a480-ad75-11ea-87be-eb42aad9740e.png)
(Note the additional "Count 1:1" section that's being added here)

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
