### PR TITLE
Increase min-height only when popover is open

### DIFF
--- a/src/app/modules/evaluate/component/evaluate-dialog/evaluate-dialog.component.html
+++ b/src/app/modules/evaluate/component/evaluate-dialog/evaluate-dialog.component.html
@@ -10,12 +10,14 @@
     [propertyMinRange]="data.settings.evaluatePropertyMinRange / 100"
     [propertyMaxRange]="data.settings.evaluatePropertyMaxRange / 100"
     [opacity]="data.settings.dialogOpacity"
+    [filterOptionsOpen]="filterOptionsOpen"
   >
     <ng-container *ngIf="currencies$ | async as currencies; else loading">
       <app-evaluate-options
         [options]="options"
         (optionsChange)="onOptionsChange($event)"
         (resetTrigger)="onReset()"
+        (toggleOpen)="onToggleOpen($event)"
       >
       </app-evaluate-options>
       <ng-container *ngIf="rate$ | async; else prediction">

--- a/src/app/modules/evaluate/component/evaluate-dialog/evaluate-dialog.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-dialog/evaluate-dialog.component.ts
@@ -45,6 +45,8 @@ export class EvaluateDialogComponent implements OnInit, AfterViewInit, OnDestroy
   public init$ = new BehaviorSubject<boolean>(false)
   public rate$ = new BehaviorSubject<boolean>(true)
 
+  public filterOptionsOpen = false
+
   constructor(
     @Inject(MAT_DIALOG_DATA)
     public data: EvaluateDialogData,
@@ -95,6 +97,10 @@ export class EvaluateDialogComponent implements OnInit, AfterViewInit, OnDestroy
   public onReset(): void {
     const queryItem = JSON.parse(JSON.stringify(this.defaultItem))
     this.onQueryItemChange(queryItem)
+  }
+
+  public onToggleOpen(openState: boolean): void {
+    this.filterOptionsOpen = openState
   }
 
   public onEvaluateResult(result: EvaluateResult): void {

--- a/src/app/modules/evaluate/component/evaluate-options/evaluate-options.component.html
+++ b/src/app/modules/evaluate/component/evaluate-options/evaluate-options.component.html
@@ -1,6 +1,6 @@
 <div class="options">
-  <mat-icon class="clickable" (click)="toggle$.next(!toggle$.value)">filter_list</mat-icon>
-  <div class="popover" *ngIf="toggle$ | async">
+  <mat-icon class="clickable" (click)="openClose()">filter_list</mat-icon>
+  <div class="popover" *ngIf="isOpen">
     <!-- league -->
     <ng-container *ngIf="options.leagueId">
       <ng-container *ngIf="leagues$ | async as leagues">

--- a/src/app/modules/evaluate/component/evaluate-options/evaluate-options.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-options/evaluate-options.component.ts
@@ -40,7 +40,7 @@ export class EvaluateOptionsComponent implements OnInit {
   public resetTrigger = new EventEmitter<void>()
 
   @Output()
-  public toggleOpen = new EventEmitter<void>()
+  public toggleOpen = new EventEmitter<boolean>()
 
   public leagues$: Observable<LeagueMap>
   public isOpen = false

--- a/src/app/modules/evaluate/component/evaluate-options/evaluate-options.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-options/evaluate-options.component.ts
@@ -39,8 +39,11 @@ export class EvaluateOptionsComponent implements OnInit {
   @Output()
   public resetTrigger = new EventEmitter<void>()
 
-  public toggle$ = new BehaviorSubject<boolean>(false)
+  @Output()
+  public toggleOpen = new EventEmitter<void>()
+
   public leagues$: Observable<LeagueMap>
+  public isOpen = false
 
   constructor(private readonly leagues: LeaguesService) {}
 
@@ -132,5 +135,10 @@ export class EvaluateOptionsComponent implements OnInit {
 
   public getIndexedText(): string {
     return this.options.indexed.replace(/\d/, '')
+  }
+
+  public openClose(): void {
+    this.isOpen = !this.isOpen
+    this.toggleOpen.emit(this.isOpen)
   }
 }

--- a/src/app/shared/module/poe/component/item-frame-header/item-frame-header.component.html
+++ b/src/app/shared/module/poe/component/item-frame-header/item-frame-header.component.html
@@ -1,10 +1,6 @@
 <div [class]="'header ' + (item.rarity || '')" [class.double]="item.name && item.typeId">
   <div class="name" *ngIf="item.name">
-    <app-item-frame-query
-      [(property)]="queryItem.name"
-      [value]="item.name"
-      [disabled]="!queryable"
-    >
+    <app-item-frame-query [(property)]="queryItem.name" [value]="item.name" [disabled]="!queryable">
       <span> {{ item.name }}</span>
     </app-item-frame-query>
   </div>

--- a/src/app/shared/module/poe/component/item-frame/item-frame.component.html
+++ b/src/app/shared/module/poe/component/item-frame/item-frame.component.html
@@ -12,7 +12,7 @@
   >
   </app-item-frame-header>
 
-  <div class="detail">
+  <div class="detail" [class.popover-open]="filterOptionsOpen">
     <!-- properties -->
     <ng-container *ngIf="item.properties">
       <app-item-frame-properties

--- a/src/app/shared/module/poe/component/item-frame/item-frame.component.scss
+++ b/src/app/shared/module/poe/component/item-frame/item-frame.component.scss
@@ -15,7 +15,11 @@
     position: relative;
     padding: 2px;
     min-width: 396px;
-    min-height: 205px;
+    min-height: 115px;
     white-space: pre;
+
+    &.popover-open {
+      min-height: 200px;
+    }
   }
 }

--- a/src/app/shared/module/poe/component/item-frame/item-frame.component.ts
+++ b/src/app/shared/module/poe/component/item-frame/item-frame.component.ts
@@ -50,6 +50,9 @@ export class ItemFrameComponent implements OnInit {
   @Input()
   public properties: []
 
+  @Input()
+  public filterOptionsOpen = false
+
   public req: boolean
   public sockets: boolean
   public stats: boolean


### PR DESCRIPTION
## Description

Fixes #52 

## Replication Steps

Open Item Frame and open/close filter options

## Screenshots/Video

![image](https://user-images.githubusercontent.com/28812961/84792259-42a2d680-afb9-11ea-8429-aee8140ffded.png)
![image](https://user-images.githubusercontent.com/28812961/84792293-4df60200-afb9-11ea-861d-6d7148c1f9cb.png)
(it looks a little taller than needed, but the league info isn't available yet)

## How Has This Been Tested?

- [x] ran `npm run ng:lint`
- [x] ran `npm run format`
- [x] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
