### PR TITLE
Updated to version 0.7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ Thumbs.db
 
 # custom
 animation.flag
+/.vs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poe-overlay",
-  "version": "0.6.28",
+  "version": "0.7.1",
   "private": true,
   "description": "A Overlay for Path of Exile. Built with Electron and Angular.",
   "main": "main.js",


### PR DESCRIPTION
## Description
Updated to version 0.7.1
Built updated setup installer
The 0.7.1 binaries can be downloaded at https://github.com/Digitalroot/PoE-Overlay-Community-Fork/releases/tag/v0.7.1

## Replication Steps
- Install WebStorm
- Install Node
- Install NPM
- Run: "electron:windows": "npm run build:prod && electron-builder build --windows",

## How Has This Been Tested?
- [x] manually tested
