### PR TITLE
Remove dependency of test 'ItemExchangeRateService should get rate'

### DIFF
--- a/doc/poe-ninja/itemcategory_prophecy_cache.json
+++ b/doc/poe-ninja/itemcategory_prophecy_cache.json
@@ -1,0 +1,23 @@
+{
+    "values": [
+        {
+            "name": "Hunter's Lesson",
+            "type": null,
+            "mapTier": 0,
+            "links": 0,
+            "relic": false,
+            "change": 0,
+            "history": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            ],
+            "chaosAmount": 1,
+            "url": "https://poe.ninja/challenge/prophecies"
+        }
+    ]
+}

--- a/src/spec_helper.spec.ts
+++ b/src/spec_helper.spec.ts
@@ -7,6 +7,7 @@ let cache: CacheService
 const mockLeagues: any = require('doc/poe/api_trade_data_leagues.json')
 const mockStaticData: any = require('doc/poe/mockCurrenciesCache.json')
 const mockExchangeRates: any = require('doc/poe-ninja/currencyoverviewcache.json')
+const mockItemCategoryProphecy: any = require('doc/poe-ninja/itemcategory_prophecy_cache.json')
 
 beforeAll((done) => {
   cache = TestBed.inject<CacheService>(CacheService)
@@ -14,5 +15,6 @@ beforeAll((done) => {
     cache.store(`leagues_1`, mockLeagues.result, 99999, true),
     cache.store('currency_chaos_equivalents_Delirium', mockExchangeRates, 99999, true),
     cache.store('currencies_1', mockStaticData, 99999, true),
+    cache.store('item_category_Delirium_prophecy', mockItemCategoryProphecy, 99999, true),
   ]).subscribe(() => done())
 })


### PR DESCRIPTION
## Description

Remove dependency of test 'ItemExchangeRateService should get rate for item' from online poe.ninja API by mocking the test data in the local cache.

## Replication Steps

Run tests disconnected from the internet. They will fail.

## Screenshots/Video

<!--  Any screenshots or video of changes  -->

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [x] ran `npm run ng:test`
- [ ] added unit tests
- [ ] manually tested
