### PR TITLE
Bugfix: Timeless Jewel Stats

### DIFF
--- a/src/app/shared/module/poe/service/item/query/item-search-filters-stats.service.ts
+++ b/src/app/shared/module/poe/service/item/query/item-search-filters-stats.service.ts
@@ -77,10 +77,10 @@ export class ItemSearchFiltersStatsService implements ItemSearchFiltersService {
         }
       } else if (min !== undefined) {
         if (min > 0 || (min === 0 && negate === 1)) {
-          max = 99999
+          max = 999999
         } else {
           max = min
-          min = -99999
+          min = -999999
         }
       } else if (max !== undefined) {
         if (max >= 0) {


### PR DESCRIPTION
## Description

When searching/evaluating for timeless jewels, there are no results being found.

## Replication Steps

Example item:
![image](https://user-images.githubusercontent.com/4527188/85030231-7c243f00-b17d-11ea-89ec-b7692aa44064.png)

```
Rarity: Unique
Elegant Hubris
Timeless Jewel
--------
Limited to: 1 Historic
Radius: Large
--------
Item Level: 81
--------
Commissioned 153800 coins to commemorate Victario
Passives in radius are Conquered by the Eternal Empire
Historic
--------
They believed themselves better than the past, but that confidence brought about nightmare.
--------
Place into an allocated Jewel Socket on the Passive Skill Tree. Right click to remove from the Socket.
--------
Note: 240SpellCrit/Witch=100c
```

As you can see the value (153.800) is > 99.999 ; which is the max value being used when searching for stats.

To fix this, I've increased the max value to 999.999

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
