### PR TITLE
Bugfix: Cluster Jewel Item Category

### DIFF
--- a/src/app/modules/evaluate/component/evaluate-dialog/evaluate-dialog.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-dialog/evaluate-dialog.component.ts
@@ -128,6 +128,7 @@ export class EvaluateDialogComponent implements OnInit, AfterViewInit, OnDestroy
       switch (this.data.item.category) {
         case ItemCategory.Jewel:
         case ItemCategory.JewelAbyss:
+        case ItemCategory.JewelCluster:
         case ItemCategory.Flask:
         case ItemCategory.Weapon:
         case ItemCategory.WeaponOne:

--- a/src/app/shared/module/poe/provider/item-category-values.provider.ts
+++ b/src/app/shared/module/poe/provider/item-category-values.provider.ts
@@ -101,6 +101,7 @@ export class ItemCategoryValuesProvider {
       }
       case ItemCategory.Jewel:
       case ItemCategory.JewelAbyss:
+      case ItemCategory.JewelCluster:
         if (rarity === ItemRarity.Unique) {
           const key = `${leagueId}_${ItemCategory.Jewel}`
           return this.fetch(key, () => this.fetchItem(leagueId, ItemOverviewType.UniqueJewel))

--- a/src/app/shared/module/poe/service/item/query/item-search-filters-type.service.ts
+++ b/src/app/shared/module/poe/service/item/query/item-search-filters-type.service.ts
@@ -85,6 +85,7 @@ export class ItemSearchFiltersTypeService implements ItemSearchFiltersService {
       // jewel
       case ItemCategory.Jewel:
       case ItemCategory.JewelAbyss:
+      case ItemCategory.JewelCluster:
       // flasks
       case ItemCategory.Flask:
       // map

--- a/src/app/shared/module/poe/type/item.type.ts
+++ b/src/app/shared/module/poe/type/item.type.ts
@@ -84,6 +84,7 @@ export enum ItemCategory {
   GemSupportGemplus = 'gem.supportgemplus',
   Jewel = 'jewel',
   JewelAbyss = 'jewel.abyss',
+  JewelCluster = 'jewel.cluster',
   Flask = 'flask',
   Map = 'map',
   MapFragment = 'map.fragment',


### PR DESCRIPTION
## Description

Last league introduced Cluster Jewels, they have their own item category on the trade website, thus can (and should) be classified as such when searching.

To facilitate this, the Item Category had to be added to the code.

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
