### PR TITLE
Add End Home PageDown PageUp Insert Delete as shortcut options

### DIFF
--- a/src/app/shared/module/material/component/accelerator/accelerator.component.ts
+++ b/src/app/shared/module/material/component/accelerator/accelerator.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core'
 
 /* tslint:disable */
-const KEY_CODES = /^(F24|F23|F22|F21|F20|F19|F18|F17|F16|F15|F14|F13|F12|F11|F10|F9|F8|F7|F6|F5|F4|F3|F2|F1|[0-9A-Z]|[`|<])$/
+const KEY_CODES = /^(F24|F23|F22|F21|F20|F19|F18|F17|F16|F15|F14|F13|F12|F11|F10|F9|F8|F7|F6|F5|F4|F3|F2|F1|End|Home|Insert|Delete|PageUp|PageDown|[0-9A-Z]|[`|<])$/
 /* tslint:enable */
 
 const PRESERVERED_ACCELERATORS = ['CmdOrCtrl + C', 'CmdOrCtrl + V', 'Alt + F4']


### PR DESCRIPTION
## Description
Added End, Home, PageDown, PageUp, Insert, Delete as available keys for command shorcuts.

## Replication Steps
1. Open Overlay Settings
2. Go to Commands Tab
3. Click Keyboard icon to replace an existing shortcut (or add new shortcut).
4. Try pressing any keys mentioned in the description.
5. Confirm shortcut saves and works.

## Screenshots/Video

![image](https://user-images.githubusercontent.com/15220647/85188610-15368100-b276-11ea-82ed-f468f74a74a1.png)


## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [x] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
