### PR TITLE
More default stats

### DIFF
--- a/src/app/modules/evaluate/evaluate.module.ts
+++ b/src/app/modules/evaluate/evaluate.module.ts
@@ -61,9 +61,11 @@ export class EvaluateModule implements FeatureModule {
         'pseudo.pseudo_total_energy_shield': true,
         'pseudo.pseudo_increased_energy_shield': true,
         'pseduo.pseudo_increased_movement_speed': true,
-        'explicit.stat_1479533453': true,
-        'enchant.stat_290368246': true,
-        'implicit.stat_299373046': true,
+        'explicit.stat_1479533453': true,// Sextant Uses
+        'enchant.stat_290368246': true,// Sextant Uses
+        'implicit.stat_299373046': true,// Blighted
+        'implicit.stat_1792283443': true,// Shaper/Elder influences maps
+        'implicit.stat_3624393862': true,// Guardian occupied maps
       },
       evaluateQueryDefaultStatsUnique: true,
       evaluateQueryIndexedRange: ItemSearchIndexed.UpTo3DaysAgo,


### PR DESCRIPTION
## Description

The app has some stats in the "default" settings. This PR expands that list to include:
* Shaper/Elder Influenced maps
* Guardian Occupied maps

Both of these stats are quite important when evaluating maps with such influence/occupation as their price is often much higher than the original map without influence/occupation.

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
