### PR TITLE
Bugfix: Single & Plural stats

### DIFF
--- a/src/app/shared/module/poe/service/stats/stats.service.ts
+++ b/src/app/shared/module/poe/service/stats/stats.service.ts
@@ -190,29 +190,48 @@ export class StatsService {
               }
             }
 
-            const text = test[0]
+            const sectionText = test[0]
+            let matchedText = sectionText
+            let matchedPredicate = predicate
+            let matchedValues = test.slice(1).map((x) => ({ text: x }))
+
+            // Check if your predicate uses a single number (e.g. '1 Added Passive Skill is a Jewel Socket' or 'Bow Attacks fire an additional Arrow')
+            if (predicate === '1' && stat.option !== true) {
+              const predicateArray: string[] = []
+              for (const otherPredicate in predicates) {
+                predicateArray.push(otherPredicate)
+              }
+              // Check if the 'next' predicate is an 'any' ('#') number predicate, if it is, then use it accordingly
+              let otherPredicate = predicateArray[predicateArray.indexOf(predicate) + 1]
+              if (otherPredicate !== undefined && otherPredicate.indexOf('#') !== -1) {
+                matchedPredicate = otherPredicate
+                matchedText = predicates[otherPredicate]
+                matchedValues = [{ text: '1' }]
+              }
+            }
+
             const itemStat: ItemStat = {
               id: stat.id,
               mod: stat.mod,
               option: stat.option,
               negated: stat.negated,
-              predicate,
+              predicate: matchedPredicate,
               type,
               tradeId,
-              values: test.slice(1).map((x) => ({ text: x })),
+              values: matchedValues,
               indistinguishable,
             }
             results.push({
               stat: itemStat,
-              match: { index: section.index, text },
+              match: { index: section.index, text: matchedText },
             })
 
             const length = section.text.length
             if (section.text[expr.lastIndex] === '\n') {
-              section.text = section.text.replace(`${text}\n`, '')
+              section.text = section.text.replace(`${sectionText}\n`, '')
             }
             if (section.text.length === length) {
-              section.text = section.text.replace(`${text}`, '')
+              section.text = section.text.replace(`${sectionText}`, '')
             }
             if (section.text.trim().length === 0) {
               search.sections.splice(index, 1)


### PR DESCRIPTION
## Description

Added better support for single & plural stats where the single stat will use the plural stat's display and value placeholders.

This fixes https://github.com/PoE-Overlay-Community/PoE-Overlay-Community-Fork/issues/121

## Replication Steps

```
Rarity: Unique
Voices
Large Cluster Jewel
--------
Item Level: 75
--------
Adds 3 Jewel Socket Passive Skills
Adds 1 Small Passive Skill which grants nothing
--------
Only a madman would ignore a god's instructions.
--------
Place into an allocated Large Jewel Socket on the Passive Skill Tree. Added passives do not interact with jewel radiuses. Right click to remove from the Socket.
--------
Corrupted
```

## Screenshots/Video

Old:
![image](https://user-images.githubusercontent.com/4527188/88314011-9de08b00-cd14-11ea-829f-b6dd82b8b8aa.png)
(Note how you cannot change the "1" in the bottom stat)

New:
![image](https://user-images.githubusercontent.com/4527188/88314121-c10b3a80-cd14-11ea-9975-564b79a92994.png)
(Note how the "1" can now be changed, and the fact that the text uses the plural version instead of singular version)

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
