### PR TITLE
Feature: 'maps' mod support

### DIFF
--- a/src/app/shared/module/poe/service/item/parser/item-section-stats-parser.service.ts
+++ b/src/app/shared/module/poe/service/item/parser/item-section-stats-parser.service.ts
@@ -43,6 +43,7 @@ export class ItemSectionStatsParserService implements ItemSectionParserService {
   private createOptions(item: Item): StatsSearchOptions {
     const options: StatsSearchOptions = {
       monsterSample: item.category === ItemCategory.MonsterSample,
+      map: item.category === ItemCategory.Map,
     }
     if (!item.properties) {
       return options

--- a/src/app/shared/module/poe/service/stats/stats.service.ts
+++ b/src/app/shared/module/poe/service/stats/stats.service.ts
@@ -12,6 +12,7 @@ export interface StatsSearchResult {
 
 export interface StatsSearchOptions {
   monsterSample?: boolean
+  map?: boolean
   base_chance_to_poison_on_hit__?: boolean
   local_minimum_added_physical_damagelocal_maximum_added_physical_damage?: boolean
   local_minimum_added_fire_damagelocal_maximum_added_fire_damage?: boolean
@@ -164,6 +165,11 @@ export class StatsService {
             const test = expr.exec(section.text)
 
             if (!test) {
+              continue
+            }
+
+            // Check if we're explicitly dealing with maps and map mods
+            if (stat.mod == "maps" && !options.map) {
               continue
             }
 


### PR DESCRIPTION
## Description

* Added support for 'maps' mod to the stats service

Note: This fixes issue https://github.com/PoE-Overlay-Community/PoE-Overlay-Community-Fork/issues/133

## Replication Steps

The following item shares the `#% increased Experience gain` mod with the `#% increased Experience gain (maps)` modifier.  
Since the latter is only roll-able on maps, and we can identify if an item is a map or not, we can actually properly distinguish between the two.  
Since GGG might add similar stats that are explicitly marked for maps (with the `(maps)` suffix on the trade site), I came up with a proper solution.

```
Rarity: Unique
Perandus Signet
Paua Ring
--------
Item Level: 82
--------
+25 to maximum Mana (implicit)
--------
+26 to maximum Mana
47% increased Mana Regeneration Rate
2% increased Experience gain
2% increased Intelligence for each Unique Item Equipped
3% additional chance for Slain monsters to drop Scrolls of Wisdom
--------
"Our warehouses are bursting. Our vaults are full.
But our minds are still hungry."
- Medici Perandus, Prefect to the Treasury

```

## Screenshots/Video

![image](https://user-images.githubusercontent.com/4527188/89099524-4b782c00-d3f0-11ea-8227-315d6a7d558d.png)

(Note: Without this PR, this item would return no results at all, since it'll attempt to use the maps modifier instead)

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
