### PR TITLE
linux, make the window focusable per default only on linux

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -200,7 +200,7 @@ function createWindow(): BrowserWindow {
       allowRunningInsecureContent: serve,
       webSecurity: false,
     },
-    focusable: false,
+    focusable: process.platform !== 'linux' ? false : true,
     skipTaskbar: true,
     show: false,
   })


### PR DESCRIPTION
allows the overlay to render on top of PoE while focused

## Description

Sets the default window behavior for electron to be focus able when run on Linux.
This is mostly a hack I came across a while ago while experimenting with various settings in order to get the overlay remotely usable on Linux, would love a proper solution but the issues appear to be deep-rooted in some dependencies.

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [x] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
Only tested on Linux (Manjaro XFCE)
