### PR TITLE
WIP: Add user configurable keybind to restart the overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ Thumbs.db
 
 # custom
 animation.flag
+
+# node version manager
+.nvmrc

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ You can change these shortcuts in the user settings menu.
 | `F6`           | Toggle DND
 | `F7`           | Opens the user settings menu
 | `F8`           | Exits overlay
+| `F9`           | Restarts overlay
 | `Alt + Num1`   | Open `https://www.poelab.com/`
 | `Alt + Num2`   | Open `https://wraeclast.com/`
 | `Esc`          | Close latest dialog

--- a/src/app/layout/component/user-settings-form/user-settings-form.component.html
+++ b/src/app/layout/component/user-settings-form/user-settings-form.component.html
@@ -137,6 +137,13 @@
       >
       </app-accelerator>
     </div>
+    <div class="col-md-6">
+      <app-accelerator
+        [label]="'settings.relaunch-app' | translate"
+        [(value)]="settings.relaunchAppUserSettingsKeybinding"
+      >
+      </app-accelerator>
+    </div>
   </div>
 </app-card>
 

--- a/src/app/layout/page/overlay/overlay.component.ts
+++ b/src/app/layout/page/overlay/overlay.component.ts
@@ -182,6 +182,16 @@ export class OverlayComponent implements OnInit, OnDestroy {
         .add(settings.exitAppKeybinding, false, VisibleFlag.Game, VisibleFlag.Overlay)
         .subscribe(() => this.app.quit())
     }
+    if (settings.relaunchAppUserSettingsKeybinding) {
+      this.shortcut
+        .add(
+          settings.relaunchAppUserSettingsKeybinding,
+          false,
+          VisibleFlag.Game,
+          VisibleFlag.Overlay
+        )
+        .subscribe(() => this.app.relaunch())
+    }
   }
 
   private getContext(settings: UserSettings): Context {

--- a/src/app/layout/service/user-settings.service.ts
+++ b/src/app/layout/service/user-settings.service.ts
@@ -34,6 +34,7 @@ export class UserSettingsService {
         let mergedSettings: UserSettings = {
           openUserSettingsKeybinding: 'F7',
           exitAppKeybinding: 'F8',
+          relaunchAppUserSettingsKeybinding: 'F9',
           language: Language.English,
           uiLanguage: UiLanguage.English,
           zoom: 100,

--- a/src/app/layout/type/user-settings.type.ts
+++ b/src/app/layout/type/user-settings.type.ts
@@ -11,6 +11,7 @@ export interface UserSettings {
   language?: Language
   uiLanguage?: UiLanguage
   openUserSettingsKeybinding?: string
+  relaunchAppUserSettingsKeybinding?: string
   exitAppKeybinding?: string
   zoom?: number
   dialogSpawnPosition?: DialogSpawnPosition


### PR DESCRIPTION
## Description

This PR adds a user configurable keybind to restart the overlay.

This was something I was looking for (as well as a few other small things like my comment in #85) so why not give it a shot and get more familiar with the repo at the same time. Apologies if I am missing anything obvious, I am open to feedback from anyone.

Bonus:
- Show keybind in context menu when clicking system icon

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested

Resources:
https://www.electronjs.org/docs/api/app#apprelaunchoptions