### PR TITLE
Bugfix: 'Seeker Ruins' cluster jewel notable

### DIFF
--- a/src/app/shared/module/poe/service/item/parser/item-section-prophecy-parser.service.ts
+++ b/src/app/shared/module/poe/service/item/parser/item-section-prophecy-parser.service.ts
@@ -6,6 +6,7 @@ import {
   ItemSection,
   ItemSectionParserService,
   Section,
+  ItemCategory,
 } from '@shared/module/poe/type'
 import { ClientStringService } from '../../client-string/client-string.service'
 
@@ -19,7 +20,11 @@ export class ItemSectionProphecyParserService implements ItemSectionParserServic
   public section = ItemSection.Prophecy
 
   public parse(item: ExportedItem, target: Item): Section {
-    const phrases = this.clientString.translateMultiple(new RegExp('^Prophecy'))
+    if (target.category != ItemCategory.Prophecy) {
+      return null
+    }
+    
+    const phrases = this.clientString.translateMultiple(new RegExp('^Prophecy(?!(Tab|Popup))'))
 
     const prophecySection = item.sections.find(
       (section) => phrases.findIndex((phrase) => section.content.indexOf(phrase) !== -1) !== -1


### PR DESCRIPTION
## Description
See https://github.com/PoE-Overlay-Community/PoE-Overlay-Community-Fork/issues/136

## Changes
* Added an additional item category check to the prophecy parser service and updated the regex to exclude Tab and Popup translations

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
