### PR TITLE
Bugfix: Blighted map exchange rate

### DIFF
--- a/src/app/modules/evaluate/provider/evaluate-query-item.provider.ts
+++ b/src/app/modules/evaluate/provider/evaluate-query-item.provider.ts
@@ -23,6 +23,7 @@ export class EvaluateQueryItemProvider {
       corrupted: item.corrupted,
       unidentified: item.unidentified,
       veiled: item.veiled,
+      blighted: item.blighted,
       influences: item.influences || {},
       damage: {},
       stats: [],

--- a/src/app/shared/module/poe/component/item-frame-header/item-frame-header.component.html
+++ b/src/app/shared/module/poe/component/item-frame-header/item-frame-header.component.html
@@ -5,12 +5,11 @@
     </app-item-frame-query>
   </div>
   <div class="name" *ngIf="item.typeId">
-    <app-item-frame-query
-      [(property)]="queryItem.typeId"
-      [value]="item.typeId"
-      [disabled]="!queryable"
-    >
-      <span>{{ item.typeId | baseItemType: language }}</span>
+    <app-item-frame-query [(property)]="queryItem.typeId"
+                          [value]="item.typeId"
+                          [disabled]="!queryable">
+      <span *ngIf="!item.blighted">{{ item.typeId | baseItemType: language }}</span>
+      <span *ngIf="item.blighted">{{ ('InfectedMap' | clientString: language).replace('{0}', (item.typeId | baseItemType: language)) }}</span>
     </app-item-frame-query>
   </div>
 </div>

--- a/src/app/shared/module/poe/service/item/item-exchange-rate.service.ts
+++ b/src/app/shared/module/poe/service/item/item-exchange-rate.service.ts
@@ -7,6 +7,7 @@ import {
 } from '../../provider/item-category-values.provider'
 import { Currency, Item, Language, ItemCategory } from '../../type'
 import { BaseItemTypesService } from '../base-item-types/base-item-types.service'
+import { ClientStringService } from '../client-string/client-string.service'
 import { ContextService } from '../context.service'
 import { CurrencyConverterService } from '../currency/currency-converter.service'
 import { CurrencySelectService, CurrencySelectStrategy } from '../currency/currency-select.service'
@@ -34,7 +35,8 @@ export class ItemExchangeRateService {
     private readonly currencyConverterService: CurrencyConverterService,
     private readonly currencySelectService: CurrencySelectService,
     private readonly baseItemTypesService: BaseItemTypesService,
-    private readonly wordService: WordService
+    private readonly wordService: WordService,
+    private readonly clientString: ClientStringService,
   ) {}
 
   public get(
@@ -179,6 +181,11 @@ export class ItemExchangeRateService {
           // Remove the discriminator from the item name.
           if (name.endsWith(')')) {
             name = name.substr(0, name.lastIndexOf('(')).trim()
+          }
+          break
+        case ItemCategory.Map:
+          if (item.blighted) {
+            name = this.clientString.translate('InfectedMap').replace('{0}', name)
           }
           break
       }

--- a/src/app/shared/module/poe/service/item/parser/item-section-rarity-parser.service.ts
+++ b/src/app/shared/module/poe/service/item/parser/item-section-rarity-parser.service.ts
@@ -76,6 +76,11 @@ export class ItemSectionRarityParserService implements ItemSectionParserService 
       return null
     }
 
+    const blightedMapItemNameDisplay = this.clientString.translate('InfectedMap').replace('{0}', this.baseItemTypesService.translate(target.typeId));
+    if (target.type === blightedMapItemNameDisplay) {
+      target.blighted = true
+    }
+
     const metamorphSamplePhrase = this.clientString.translate('MetamorphosisItemisedMapBoss')
 
     const metamorphSample = item.sections.find(

--- a/src/app/shared/module/poe/type/item.type.ts
+++ b/src/app/shared/module/poe/type/item.type.ts
@@ -14,6 +14,7 @@ export interface Item {
   corrupted?: boolean
   unidentified?: boolean
   veiled?: boolean
+  blighted?: boolean
   damage?: ItemWeaponDamage
   sockets?: ItemSocket[]
   properties?: ItemProperties


### PR DESCRIPTION
## Description

See #146 

## Changes
* Added support to identify Blighted maps and updated the item header to show this
* Updated the item exchange rate service to take blighted maps into account

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
