### PR TITLE
Feature: Multiple monitor support

### DIFF
--- a/src/app/core/service/dialog/dialog.service.ts
+++ b/src/app/core/service/dialog/dialog.service.ts
@@ -31,15 +31,14 @@ export class DialogService {
     { position: point, width, height }: DialogSettings,
     focusable: boolean
   ): Observable<R> {
-    const bounds = this.window.getBounds()
+    const displayBounds = this.window.gameBounds.value
+    const windowBounds = this.window.getWindowBounds()
 
-    const local = point
-      ? this.window.convertToLocal(point)
-      : { x: bounds.width * 0.5, y: bounds.height * 0.5 }
+    const local = this.window.convertToLocal(point ?? { x: displayBounds.width * 0.5, y: displayBounds.height * 0.5 })
     const scaled = this.window.convertToLocalScaled(local)
 
-    const left = Math.max(Math.min(scaled.x - width * 0.5, bounds.width - width), 0)
-    const top = Math.max(Math.min(scaled.y - height * 0.5, bounds.height - height), 0)
+    const left = Math.max(Math.min(scaled.x - width * 0.5, windowBounds.width - width), 0)
+    const top = Math.max(Math.min(scaled.y - height * 0.5, windowBounds.height - height), 0)
 
     if (this.dialog.openDialogs.length === 0) {
       this.window.enableInput(focusable)

--- a/src/app/core/service/window.service.ts
+++ b/src/app/core/service/window.service.ts
@@ -14,7 +14,7 @@ export class WindowService {
   constructor(private readonly ngZone: NgZone, electronProvider: ElectronProvider) {
     const electron = electronProvider.provideRemote()
     this.window = electron.getCurrentWindow()
-    this.gameBounds = new BehaviorSubject<Rectangle>(this.window.getBounds())
+    this.gameBounds = new BehaviorSubject<Rectangle>(this.window?.getBounds() ?? {x: 0, y: 0, width: 0, height: 0})
 
     electronProvider.provideIpcRenderer().on('game-bounds-change', (_, bounds: Rectangle) => {
       this.gameBounds.next(bounds)

--- a/src/app/core/service/window.service.ts
+++ b/src/app/core/service/window.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NgZone } from '@angular/core'
 import { ElectronProvider } from '@app/provider'
 import { Rectangle } from '@app/type'
-import { BrowserWindow, Point } from 'electron'
+import { BrowserWindow, Point, IpcRenderer } from 'electron'
 import { Observable, Subject, BehaviorSubject } from 'rxjs'
 
 @Injectable({
@@ -9,14 +9,19 @@ import { Observable, Subject, BehaviorSubject } from 'rxjs'
 })
 export class WindowService {
   public readonly gameBounds: BehaviorSubject<Rectangle>
+
+  private readonly ipcRenderer: IpcRenderer
   private readonly window: BrowserWindow
 
   constructor(private readonly ngZone: NgZone, electronProvider: ElectronProvider) {
+    this.ipcRenderer = electronProvider.provideIpcRenderer()
     const electron = electronProvider.provideRemote()
     this.window = electron.getCurrentWindow()
     this.gameBounds = new BehaviorSubject<Rectangle>(this.window?.getBounds() ?? {x: 0, y: 0, width: 0, height: 0})
+  }
 
-    electronProvider.provideIpcRenderer().on('game-bounds-change', (_, bounds: Rectangle) => {
+  public registerEvents(): void {
+    this.ipcRenderer.on('game-bounds-change', (_, bounds: Rectangle) => {
       this.gameBounds.next(bounds)
     })
   }

--- a/src/app/layout/page/overlay/overlay.component.html
+++ b/src/app/layout/page/overlay/overlay.component.html
@@ -1,9 +1,10 @@
 <div class="game-overlay"
      id="game-overlay"
-     [style.left]="(gameOverlayBounds | async).x + 'px'"
-     [style.top]="(gameOverlayBounds | async).y + 'px'"
-     [style.width]="(gameOverlayBounds | async).width + 'px'"
-     [style.height]="(gameOverlayBounds | async).height + 'px'"
+     *ngIf="(gameOverlayBounds | async) as gameOverlayBounds"
+     [style.left]="gameOverlayBounds.x + 'px'"
+     [style.top]="gameOverlayBounds.y + 'px'"
+     [style.width]="gameOverlayBounds.width + 'px'"
+     [style.height]="gameOverlayBounds.height + 'px'"
      >
   <div class="version" *ngIf="displayVersion$ | async">PoE Overlay: {{ version$ | async }}</div>
 </div>

--- a/src/app/layout/page/overlay/overlay.component.html
+++ b/src/app/layout/page/overlay/overlay.component.html
@@ -1,1 +1,9 @@
-<div class="version" *ngIf="displayVersion$ | async">PoE Overlay: {{ version$ | async }}</div>
+<div class="game-overlay"
+     id="game-overlay"
+     [style.left]="(gameOverlayBounds | async).x + 'px'"
+     [style.top]="(gameOverlayBounds | async).y + 'px'"
+     [style.width]="(gameOverlayBounds | async).width + 'px'"
+     [style.height]="(gameOverlayBounds | async).height + 'px'"
+     >
+  <div class="version" *ngIf="displayVersion$ | async">PoE Overlay: {{ version$ | async }}</div>
+</div>

--- a/src/app/layout/page/overlay/overlay.component.scss
+++ b/src/app/layout/page/overlay/overlay.component.scss
@@ -1,8 +1,12 @@
 @import './../../../../styles/variables';
 
+.game-overlay {
+    position: fixed;
+}
+
 .version {
   color: $yellow;
-  position: fixed;
+  position: absolute;
   bottom: 2px;
   left: 2px;
   font-size: 9px;

--- a/src/app/layout/page/overlay/overlay.component.ts
+++ b/src/app/layout/page/overlay/overlay.component.ts
@@ -10,7 +10,7 @@ import { AppService, AppTranslateService, RendererService, WindowService } from 
 import { DialogRefService } from '@app/service/dialog'
 import { ShortcutService } from '@app/service/input'
 import { FEATURE_MODULES } from '@app/token'
-import { AppUpdateState, FeatureModule, VisibleFlag } from '@app/type'
+import { AppUpdateState, FeatureModule, VisibleFlag, Rectangle } from '@app/type'
 import { SnackBarService } from '@shared/module/material/service'
 import { ContextService } from '@shared/module/poe/service'
 import { Context } from '@shared/module/poe/type'
@@ -28,8 +28,9 @@ import { UserSettings } from '../../type'
 export class OverlayComponent implements OnInit, OnDestroy {
   private userSettingsOpen: Observable<void>
 
-  public version$ = new BehaviorSubject<string>('')
-  public displayVersion$ = new BehaviorSubject(true)
+  public readonly version$ = new BehaviorSubject<string>('')
+  public readonly displayVersion$ = new BehaviorSubject(true)
+  public readonly gameOverlayBounds: BehaviorSubject<Rectangle>
 
   constructor(
     @Inject(FEATURE_MODULES)
@@ -43,7 +44,12 @@ export class OverlayComponent implements OnInit, OnDestroy {
     private readonly renderer: RendererService,
     private readonly shortcut: ShortcutService,
     private readonly dialogRef: DialogRefService
-  ) {}
+  ) {
+    this.gameOverlayBounds = new BehaviorSubject<Rectangle>(this.window.getOffsettedGameBounds())
+    this.window.gameBounds.subscribe((_) => {
+      this.gameOverlayBounds.next(this.window.getOffsettedGameBounds())
+    })
+  }
 
   @HostListener('window:beforeunload', [])
   public onWindowBeforeUnload(): void {

--- a/src/app/layout/page/overlay/overlay.component.ts
+++ b/src/app/layout/page/overlay/overlay.component.ts
@@ -107,6 +107,7 @@ export class OverlayComponent implements OnInit, OnDestroy {
       }
     })
     this.app.registerEvents(settings.autoDownload)
+    this.window.registerEvents()
   }
 
   private registerVisibleChange(): void {

--- a/src/app/shared/module/material/service/snack-bar.service.ts
+++ b/src/app/shared/module/material/service/snack-bar.service.ts
@@ -35,13 +35,17 @@ export class SnackBarService {
         .pipe(
           flatMap(([translatedMessage, translatedAction]) => {
             let snackBar = this.matSnackBar.open(translatedMessage, translatedAction, {
-              duration: 5 * 10000,
+              duration: 5 * 1000,
               verticalPosition: 'bottom',
               panelClass: ['snack-bar-service', panelClass],
             })
-            let snackBarElement = document.getElementsByClassName('snack-bar-service')[0]
+            let snackBarElements = document.querySelectorAll('.snack-bar-service')
             let gameOverlayElement = document.getElementById('game-overlay')
-            gameOverlayElement.append(snackBarElement.parentNode.parentNode)
+            if (gameOverlayElement !== undefined) {
+              snackBarElements.forEach((snackBarElement) => {
+                gameOverlayElement.append(snackBarElement.parentNode.parentNode)
+              });
+            }
             return snackBar.onAction()
           })
         )

--- a/src/app/shared/module/material/service/snack-bar.service.ts
+++ b/src/app/shared/module/material/service/snack-bar.service.ts
@@ -33,15 +33,17 @@ export class SnackBarService {
     return from(
       forkJoin([this.translate.get(message), action ? this.translate.get(action) : of(undefined)])
         .pipe(
-          flatMap(([translatedMessage, translatedAction]) =>
-            this.matSnackBar
-              .open(translatedMessage, translatedAction, {
-                duration: 5 * 1000,
-                verticalPosition: 'bottom',
-                panelClass: ['snack-bar-service', panelClass],
-              })
-              .onAction()
-          )
+          flatMap(([translatedMessage, translatedAction]) => {
+            let snackBar = this.matSnackBar.open(translatedMessage, translatedAction, {
+              duration: 5 * 10000,
+              verticalPosition: 'bottom',
+              panelClass: ['snack-bar-service', panelClass],
+            })
+            let snackBarElement = document.getElementsByClassName('snack-bar-service')[0]
+            let gameOverlayElement = document.getElementById('game-overlay')
+            gameOverlayElement.append(snackBarElement.parentNode.parentNode)
+            return snackBar.onAction()
+          })
         )
         .toPromise()
     )

--- a/src/app/shared/module/poe/service/stash/stash.service.ts
+++ b/src/app/shared/module/poe/service/stash/stash.service.ts
@@ -46,7 +46,7 @@ export class StashService {
 
   public hovering(point?: Point): boolean {
     point = point || this.mouse.position()
-    const gameBounds = this.window.getBounds()
+    const gameBounds = this.window.gameBounds.value
 
     const stashWidth = Math.round(gameBounds.height / GAME_HEIGHT_TO_STASH_WIDTH_RATIO)
     const relativePointX = point.x - gameBounds.x


### PR DESCRIPTION
## Description

This PR aims to add support for multiple monitors, mainly the dragging/moving of the price-check dialog to a secondary monitor.  
  
My main goal was to expand the window (so it covers all screens) in which the dialogs (for price checking, etc...) are spawned so they can be moved anywhere. (currently the window is being sized to cover just PoE, making it impossible to move the dialog to a secondary monitor)  
  
When resizing the window some issues showed up and I've tried to fix them accordingly:
* When having the user setting to spawn price-checking in the 'center', this now means the center of the poe game bounds (an no longer the center of the screen).
* When the app launches, the game-version shows at the 'bottom-left', this now means the bottom-left of the poe game bounds.
* When a snack-bar is being shown, it shows at the bottom-center by default, this now means the bottom-center of the poe game bounds. (Otherwise you'd see the snack-bar split across two screens when you have a dual-monitor setup)
  * Note: When reviewing this piece of code, please let me know if there's a much better solution to get this done as I'm not an Angular/Typescript guru.

Note for all of the above issues: When no active PoE window has been found yet (mostly in debug mode, or when launching without PoE opened), the 'game bounds' are considered to be the entire window bounds, which would span all monitors. Once the PoE window is properly detected and made active (and thus its bounds are known/found), the positioning of said components is corrected/adjusted to the new PoE bounds.

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
