### PR TITLE
Bugfix: Item Exchange Rate Rounding

### DIFF
--- a/src/app/modules/evaluate/component/evaluate-exchange-rate/evaluate-exchange-rate.component.html
+++ b/src/app/modules/evaluate/component/evaluate-exchange-rate/evaluate-exchange-rate.component.html
@@ -19,7 +19,7 @@
               </mat-icon>
               <span class="amount-column">
                 <span class="amount clickable" (click)="onAmountClick($event, result.rate.amount)">
-                  {{ result.rate.amount | number: '1.2-2' }}&nbsp;</span
+                  {{ roundAmount(result.rate.amount) | number: '1.2-2' }}&nbsp;</span
                 >
                 <span
                   class="amount clickable"
@@ -32,7 +32,7 @@
                   "
                   *ngIf="result.rate.factor > 1"
                 >
-                  {{ result.rate.amount * result.rate.factor | number: '1.2-2' }}&nbsp;</span
+                  {{ roundAmount(result.rate.amount * result.rate.factor) | number: '1.2-2' }}&nbsp;</span
                 >
               </span>
               <app-currency-frame class="clickable" [currency]="result.rate.currency">

--- a/src/app/modules/evaluate/component/evaluate-exchange-rate/evaluate-exchange-rate.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-exchange-rate/evaluate-exchange-rate.component.ts
@@ -106,6 +106,10 @@ export class EvaluateExchangeRateComponent implements OnInit {
     })
   }
 
+  public roundAmount(amount: number): number {
+    return Math.ceil(amount * 100) / 100
+  }
+
   private evaluate(item: Item, currency?: Currency): void {
     this.exchangeRate
       .get(item, currency ? [currency] : this.currencies, this.options.leagueId)

--- a/src/app/shared/module/poe/service/item/item-exchange-rate.service.ts
+++ b/src/app/shared/module/poe/service/item/item-exchange-rate.service.ts
@@ -64,9 +64,9 @@ export class ItemExchangeRateService {
               )
               const size = (item.properties?.stackSize?.value?.split('/') || ['1'])[0]
               const result: ItemExchangeRateResult = {
-                amount: Math.ceil(values[index][0] * 100) / 100,
+                amount: values[index][0],
                 factor: +size.replace('.', ''),
-                inverseAmount: Math.ceil((1 / values[index][0]) * 100) / 100,
+                inverseAmount: 1 / values[index][0],
                 currency: currencies[index],
                 change: value.change,
                 history: value.history || [],


### PR DESCRIPTION
## Description

* Fixed item exchange rate rounding by moving the rounding to the view rather than early on in the exchange rate service
* This fixes issue https://github.com/PoE-Overlay-Community/PoE-Overlay-Community-Fork/issues/171

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
