### PR TITLE
Bugfix: Flask Section Parsing

### DIFF
--- a/src/app/shared/module/poe/service/item/parser/item-section-flask-parser.service.ts
+++ b/src/app/shared/module/poe/service/item/parser/item-section-flask-parser.service.ts
@@ -18,9 +18,9 @@ export class ItemSectionFlaskParserService implements ItemSectionParserService {
   public section = ItemSection.Flask
 
   public parse(item: ExportedItem, target: Item): Section {
-    const phrase = `${this.clientString.translate('ItemDisplayChargesNCharges').replace('{0}', '0')}`
+    const phrase = new RegExp(`^${this.clientString.translate('ItemDisplayChargesNCharges').replace('{0}', '(\\S+)')}$`)
 
-    const flaskSection = item.sections.find((x) => x.content.indexOf(phrase) !== -1)
+    const flaskSection = item.sections.find((x) => phrase.test(x.content))
     if (!flaskSection) {
       return null
     }


### PR DESCRIPTION
## Description

* Fixed flask section parsing by using a regex instead of plain-text search

## Replication Steps

```
Rarity: Unique
Dying Sun
Ruby Flask
--------
Lasts 4.0 Seconds
Consumes 30 of 60 Charges on use
Currently has 60 Charges
+50% to Fire Resistance
20% less Fire Damage taken
--------
Requirements:
Level: 68
--------
Item Level: 86
--------
3% increased Charges used
Skills fire 2 additional Projectiles during Flask Effect
24% increased Area of Effect during Flask Effect
--------
All things must die.
Whether you burn out or explode is up to you.
--------
Right click to drink. Can only hold charges while in belt. Refills as you kill monsters.
```

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [ ] manually tested
