### PR TITLE
Feature/bulk exchange evaluation

### DIFF
--- a/src/app/data/poe/schema/trade.ts
+++ b/src/app/data/poe/schema/trade.ts
@@ -247,7 +247,7 @@ export interface FilterOptionDiscriminator extends FilterOption {
   discriminator?: string
 }
 
-export interface Exchange {
+interface Exchange {
   status?: FilterOption
   want?: string[]
   have?: string[]
@@ -290,7 +290,7 @@ export interface TradeFetchResultListing {
   account: TradeFetchResultAccount
 }
 
-export interface TradeFetchResultItem {
+interface TradeFetchResultItem {
   note?: string
 }
 

--- a/src/app/data/poe/schema/trade.ts
+++ b/src/app/data/poe/schema/trade.ts
@@ -54,16 +54,15 @@ export interface TradeStaticResultEntry {
 
 export enum TradeStaticResultId {
   Currency = 'Currency',
+  Splinters = 'Splinters',
   Fragments = 'Fragments',
+  DeliriumOrbs = 'DeliriumOrbs',
   Catalysts = 'Catalysts',
   Oils = 'Oils',
   Incubators = 'Incubators',
   Scarabs = 'Scarabs',
   DelveResonators = 'DelveResonators',
   DelveFossils = 'DelveFossils',
-  Vials = 'Vials',
-  Nets = 'Nets',
-  Leaguestones = 'Leaguestones',
   Essences = 'Essences',
   Cards = 'Cards',
   MapsTier1 = 'MapsTier1',

--- a/src/app/data/poe/schema/trade.ts
+++ b/src/app/data/poe/schema/trade.ts
@@ -1,5 +1,3 @@
-import { ItemSearchType } from '../../../shared/module/poe/service';
-
 export interface TradeResponse<TResult> {
   result: TResult[]
 }
@@ -265,7 +263,7 @@ export interface TradeSearchRequest {
 }
 
 export interface TradeOrExchangeSearchResponse extends TradeResponse<string> {
-  searchType: ItemSearchType
+  searchType: TradeSearchType
   id: string
   url: string
   total: number
@@ -300,4 +298,9 @@ export interface TradeFetchResult {
   id: string
   listing: TradeFetchResultListing
   item: TradeFetchResultItem
+}
+
+export enum TradeSearchType {
+  NormalTrade = 'search',
+  BulkExchange = 'exchange',
 }

--- a/src/app/data/poe/schema/trade.ts
+++ b/src/app/data/poe/schema/trade.ts
@@ -1,3 +1,5 @@
+import { ItemSearchType } from '../../../shared/module/poe/service';
+
 export interface TradeResponse<TResult> {
   result: TResult[]
 }
@@ -247,6 +249,12 @@ export interface FilterOptionDiscriminator extends FilterOption {
   discriminator?: string
 }
 
+export interface Exchange {
+  status?: FilterOption
+  want?: string[]
+  have?: string[]
+}
+
 export interface Sort {
   price?: string
 }
@@ -256,10 +264,16 @@ export interface TradeSearchRequest {
   sort: Sort
 }
 
-export interface TradeSearchResponse extends TradeResponse<string> {
+export interface TradeOrExchangeSearchResponse extends TradeResponse<string> {
+  searchType: ItemSearchType
   id: string
   url: string
   total: number
+}
+
+export interface ExchangeSearchRequest {
+  exchange: Exchange
+  sort: Sort
 }
 
 export interface TradeFetchResultPrice {
@@ -278,7 +292,12 @@ export interface TradeFetchResultListing {
   account: TradeFetchResultAccount
 }
 
+export interface TradeFetchResultItem {
+  note?: string
+}
+
 export interface TradeFetchResult {
   id: string
   listing: TradeFetchResultListing
+  item: TradeFetchResultItem
 }

--- a/src/app/data/poe/service/trade-http.service.ts
+++ b/src/app/data/poe/service/trade-http.service.ts
@@ -5,7 +5,6 @@ import { environment } from '@env/environment'
 import { Language } from '@shared/module/poe/type'
 import { Observable, of, throwError } from 'rxjs'
 import { delay, flatMap, map, retryWhen } from 'rxjs/operators'
-import { ItemSearchType } from '../../../shared/module/poe/service'
 import {
   ExchangeSearchRequest,
   TradeFetchResult,
@@ -16,6 +15,7 @@ import {
   TradeOrExchangeSearchResponse,
   TradeStaticResult,
   TradeStatsResult,
+  TradeSearchType,
 } from '../schema/trade'
 import { TradeRateLimitService } from './trade-rate-limit.service'
 
@@ -58,7 +58,7 @@ export class TradeHttpService {
     language: Language,
     leagueId: string
   ): Observable<TradeOrExchangeSearchResponse> {
-    return this.searchOrExchange(request, language, leagueId, ItemSearchType.Trade)
+    return this.searchOrExchange(request, language, leagueId, TradeSearchType.NormalTrade)
   }
 
   public exchange(
@@ -66,7 +66,7 @@ export class TradeHttpService {
     language: Language,
     leagueId: string
   ): Observable<TradeOrExchangeSearchResponse> {
-    return this.searchOrExchange(request, language, leagueId, ItemSearchType.BulkExchange)
+    return this.searchOrExchange(request, language, leagueId, TradeSearchType.BulkExchange)
   }
 
   public fetch(
@@ -98,7 +98,7 @@ export class TradeHttpService {
     request: TradeSearchRequest | ExchangeSearchRequest,
     language: Language,
     leagueId: string,
-    searchType: ItemSearchType,
+    searchType: TradeSearchType,
   ): Observable<TradeOrExchangeSearchResponse> {
     const url = this.getApiUrl(`${searchType}/${encodeURIComponent(leagueId)}`, language)
     return this.limit

--- a/src/app/modules/evaluate/component/evaluate-dialog/evaluate-dialog.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-dialog/evaluate-dialog.component.ts
@@ -164,7 +164,6 @@ export class EvaluateDialogComponent implements OnInit, AfterViewInit, OnDestroy
         case ItemCategory.GemActivegem:
         case ItemCategory.GemSupportGem:
         case ItemCategory.GemSupportGemplus:
-        case ItemCategory.MapScarab:
         case ItemCategory.Leaguestone:
         case ItemCategory.MonsterSample:
         case ItemCategory.CurrencyPiece:

--- a/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.html
+++ b/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.html
@@ -22,10 +22,14 @@
           <span class="value">{{ row.amount }}</span>
         </td>
         <td class="amount" *ngIf="original">
-          <app-currency-frame [amount]="row.originalAmount" [currency]="row.originalCurrency" *ngIf="!showRatio(row)">
-          </app-currency-frame>
-          <app-currency-ratio-frame [amount]="row.originalAmount" [currency]="row.originalCurrency" [numerator]="row.priceNumerator" [denominator]="row.priceDenominator" *ngIf="showRatio(row)">
-          </app-currency-ratio-frame>
+          <ng-container *ngIf="showRatio(row); else currencyframe">
+            <app-currency-ratio-frame [amount]="row.originalAmount" [currency]="row.originalCurrency" [numerator]="row.priceNumerator" [denominator]="row.priceDenominator">
+            </app-currency-ratio-frame>
+          </ng-container>
+          <ng-template #currencyframe>
+            <app-currency-frame [amount]="row.originalAmount" [currency]="row.originalCurrency">
+            </app-currency-frame>
+          </ng-template>
         </td>
         <td>
           <span *ngIf="row.count > 1">

--- a/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.html
+++ b/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.html
@@ -8,6 +8,7 @@
     </tr>
   </table>
   <cdk-virtual-scroll-viewport class="viewport"
+                               [class.wide]="wideViewport"
                                [style.height.px]="rows.length > 20 ? 20 * 20 : (rows.length + 1) * 20"
                                itemSize="19"
                                minBufferPx="200"

--- a/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.html
+++ b/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.html
@@ -7,26 +7,24 @@
       <th class="age">{{ 'evaluate.age' | translate }}</th>
     </tr>
   </table>
-  <cdk-virtual-scroll-viewport
-    class="viewport"
-    [style.height.px]="rows.length > 20 ? 20 * 20 : (rows.length + 1) * 20"
-    itemSize="19"
-    minBufferPx="200"
-    maxBufferPx="400"
-  >
+  <cdk-virtual-scroll-viewport class="viewport"
+                               [style.height.px]="rows.length > 20 ? 20 * 20 : (rows.length + 1) * 20"
+                               itemSize="19"
+                               minBufferPx="200"
+                               maxBufferPx="400">
     <table>
-      <tr
-        *cdkVirtualFor="let row of rows; templateCacheSize: 0"
-        class="clickable"
-        [class.fixer]="row.count >= 3"
-        (click)="onRowClick($event, row)"
-      >
+      <tr *cdkVirtualFor="let row of rows; templateCacheSize: 0"
+          class="clickable"
+          [class.fixer]="row.count >= 3"
+          (click)="onRowClick($event, row)">
         <td class="amount" *ngIf="!original">
           <span class="value">{{ row.amount }}</span>
         </td>
         <td class="amount" *ngIf="original">
-          <app-currency-frame [amount]="row.originalAmount" [currency]="row.originalCurrency">
+          <app-currency-frame [amount]="row.originalAmount" [currency]="row.originalCurrency" *ngIf="!showRatio(row)">
           </app-currency-frame>
+          <app-currency-ratio-frame [amount]="row.originalAmount" [currency]="row.originalCurrency" [numerator]="row.priceNumerator" [denominator]="row.priceDenominator" *ngIf="showRatio(row)">
+          </app-currency-ratio-frame>
         </td>
         <td>
           <span *ngIf="row.count > 1">

--- a/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.scss
+++ b/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.scss
@@ -18,6 +18,7 @@ table {
 
   .amount {
     min-width: 70px;
+    text-align:right;
 
     .value {
       color: $light-grey;

--- a/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.scss
+++ b/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.scss
@@ -1,5 +1,9 @@
 @import './../../../../../styles/variables';
 
+.viewport.wide {
+    width: 430px;
+}
+
 table {
   width: 100%;
 

--- a/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.ts
@@ -4,6 +4,8 @@ import { Currency } from '@shared/module/poe/type'
 
 interface Row {
   amount: number
+  priceNumerator: number
+  priceDenominator: number
   originalAmount: number
   originalCurrency: Currency
   count: number
@@ -38,7 +40,9 @@ export class EvaluateSearchTableComponent {
       } = {}
       result.entries.forEach((item) => {
         const next: Row = {
-          amount: Math.round(item.targetAmount * 100) / 100,
+          amount: item.targetAmount,
+          priceNumerator: item.priceNumerator,
+          priceDenominator: item.priceDenominator,
           count: 1,
           originalAmount: item.originalAmount,
           originalCurrency: item.original,
@@ -73,5 +77,9 @@ export class EvaluateSearchTableComponent {
       amount: this.original ? row.originalAmount : row.amount,
       currency: this.original ? row.originalCurrency : undefined,
     })
+  }
+
+  public showRatio(row: Row): boolean {
+    return (row.priceDenominator != 1 || row.priceNumerator != row.originalAmount) && Math.floor(row.originalAmount) != row.originalAmount
   }
 }

--- a/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.ts
@@ -67,6 +67,9 @@ export class EvaluateSearchTableComponent {
   @Input()
   public original: boolean
 
+  @Input()
+  public wideViewport: boolean
+
   @Output()
   public amountSelect = new EventEmitter<SelectEvent>()
 

--- a/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.html
+++ b/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.html
@@ -133,6 +133,8 @@
     </ng-container>
     <ng-template #error>
       <div>{{ error$ | async | translate }}</div>
+      &nbsp;
+      <div class="clickable" (click)="onRetryClick()">{{ 'evaluate.try-again' | translate }}</div>
     </ng-template>
   </ng-template>
 </ng-template>

--- a/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.html
+++ b/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.html
@@ -77,6 +77,7 @@
                   *ngIf="!graph"
                   [result]="result"
                   [original]="settings.evaluateCurrencyOriginal"
+                  [wideViewport]="useWideViewport()"
                   (amountSelect)="onAmountSelect($event.amount, $event.currency)"
                 >
                 </app-evaluate-search-table>

--- a/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.ts
@@ -147,6 +147,10 @@ export class EvaluateSearchComponent implements OnInit, OnDestroy {
     this.evaluateResult.next({ amount, currency })
   }
 
+  public useWideViewport(): boolean {
+    return this.search$.value?.searchType === ItemSearchType.BulkExchange
+  }
+
   private initSearch(): void {
     this.search(this.queryItem)
     this.registerSearchOnChange()

--- a/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.ts
@@ -91,6 +91,11 @@ export class EvaluateSearchComponent implements OnInit, OnDestroy {
     this.initSearch()
   }
 
+  public onRetryClick(): void {
+    this.clear()
+    this.search(this.queryItem)
+  }
+
   public onCurrencyClick(event: MouseEvent): void {
     const search = this.search$.value
     if (search?.url?.length) {

--- a/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.ts
@@ -15,12 +15,12 @@ import {
   ItemSearchListing,
   ItemSearchResult,
   ItemSearchService,
-  ItemSearchType,
 } from '@shared/module/poe/service'
 import { Currency, Item } from '@shared/module/poe/type'
 import { ItemSearchOptions } from '@shared/module/poe/type/search.type'
 import { BehaviorSubject, Subject, Subscription, timer } from 'rxjs'
 import { debounceTime, takeUntil } from 'rxjs/operators'
+import { TradeSearchType } from '@data/poe'
 import { EvaluateOptions } from '../evaluate-options/evaluate-options.component'
 import {
   EvaluateResultView,
@@ -133,7 +133,7 @@ export class EvaluateSearchComponent implements OnInit, OnDestroy {
 
 
     const search = this.search$.value
-    if (search?.searchType === ItemSearchType.BulkExchange) {
+    if (search?.searchType === TradeSearchType.BulkExchange) {
       this.clear()
       this.search(this.queryItem, this.currencies[index])
     } else {
@@ -148,7 +148,7 @@ export class EvaluateSearchComponent implements OnInit, OnDestroy {
   }
 
   public useWideViewport(): boolean {
-    return this.search$.value?.searchType === ItemSearchType.BulkExchange
+    return this.search$.value?.searchType === TradeSearchType.BulkExchange
   }
 
   private initSearch(): void {

--- a/src/app/shared/module/poe/component/currency-ratio-frame/currency-ratio-frame.component.html
+++ b/src/app/shared/module/poe/component/currency-ratio-frame/currency-ratio-frame.component.html
@@ -1,0 +1,13 @@
+<div class="content">
+  <span class="amount" [title]="amount">
+    <span class="fraction">
+      <sup>{{ numerator | number: '1.0' }}</sup>&#8260;<sub>{{ denominator | number: '1.0' }}</sub>
+    </span>
+    <span class="decimal">
+      ({{ amount | number: '1.3-3' }})
+    </span>
+  </span>
+  <span class="currency" *ngIf="currency">
+    <img [src]="'https://web.poecdn.com' + currency.image" />
+  </span>
+</div>

--- a/src/app/shared/module/poe/component/currency-ratio-frame/currency-ratio-frame.component.scss
+++ b/src/app/shared/module/poe/component/currency-ratio-frame/currency-ratio-frame.component.scss
@@ -1,0 +1,29 @@
+@import './../../../../../../styles/variables';
+
+.content {
+  display: inline-flex;
+  justify-content: center;
+  line-height: 32px;
+  height: 32px;
+
+  .amount {
+    line-height: 15px;
+
+    .fraction {
+      color: $light-grey;
+      font-size: 14px;
+    }
+
+    .decimal {
+      font-size: 12px;
+    }
+  }
+
+  img {
+    height: 32px;
+  }
+
+  .currency {
+    display: inline-flex;
+  }
+}

--- a/src/app/shared/module/poe/component/currency-ratio-frame/currency-ratio-frame.component.ts
+++ b/src/app/shared/module/poe/component/currency-ratio-frame/currency-ratio-frame.component.ts
@@ -1,0 +1,22 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
+import { Currency, CurrencyRange } from '../../type'
+
+@Component({
+  selector: 'app-currency-ratio-frame',
+  templateUrl: './currency-ratio-frame.component.html',
+  styleUrls: ['./currency-ratio-frame.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CurrencyRatioFrameComponent {
+  @Input()
+  public currency: Currency
+
+  @Input()
+  public amount: number
+
+  @Input()
+  public numerator: number
+
+  @Input()
+  public denominator: number
+}

--- a/src/app/shared/module/poe/poe.module.ts
+++ b/src/app/shared/module/poe/poe.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core'
 import { BrowserModule } from '@angular/platform-browser'
 import { CurrencyFrameComponent } from './component/currency-frame/currency-frame.component'
+import { CurrencyRatioFrameComponent } from './component/currency-ratio-frame/currency-ratio-frame.component'
 import { ItemFrameHeaderComponent } from './component/item-frame-header/item-frame-header.component'
 import { ItemFrameInfluencesComponent } from './component/item-frame-influences/item-frame-influences.component'
 import { ItemFrameLevelRequirementsComponent } from './component/item-frame-level-requirements/item-frame-level-requirements.component'
@@ -25,6 +26,7 @@ import { ItemFrameAnnointmentComponent } from './component/item-frame-annointmen
   declarations: [
     ItemFrameComponent,
     CurrencyFrameComponent,
+    CurrencyRatioFrameComponent,
     ClientStringPipe,
     StatGroupPipe,
     StatTransformPipe,
@@ -48,6 +50,7 @@ import { ItemFrameAnnointmentComponent } from './component/item-frame-annointmen
   exports: [
     ItemFrameComponent,
     CurrencyFrameComponent,
+    CurrencyRatioFrameComponent,
     ClientStringPipe,
     WordPipe,
     BaseItemTypePipe,

--- a/src/app/shared/module/poe/service/currency/currency.service.ts
+++ b/src/app/shared/module/poe/service/currency/currency.service.ts
@@ -3,6 +3,7 @@ import { CurrenciesProvider } from '@shared/module/poe/provider'
 import { Currency, Language } from '@shared/module/poe/type'
 import { Observable } from 'rxjs'
 import { map, shareReplay } from 'rxjs/operators'
+import { TradeStaticResultId } from '../../../../../data/poe'
 import { ContextService } from '../context.service'
 
 const CACHE_SIZE = 1
@@ -23,7 +24,7 @@ export class CurrencyService {
   public get(language?: Language): Observable<Currency[]> {
     language = language || this.context.get().language
 
-    return this.currenciesProvider.provide(language)
+    return this.currenciesProvider.provide(language, TradeStaticResultId.Currency)
   }
 
   public searchById(id: string, language?: Language): Observable<Currency> {

--- a/src/app/shared/module/poe/service/item/item-search-analyze.service.spec.ts
+++ b/src/app/shared/module/poe/service/item/item-search-analyze.service.spec.ts
@@ -82,11 +82,11 @@ describe('ItemSearchAnalyzeService', () => {
     const requestedItem: Item = {
       typeId: baseItemTypesService.search('Topaz Ring'),
     }
-    itemSearchServiceSpy.search.and.returnValue(of(mockSearchResult))
+    itemSearchServiceSpy.searchOrExchange.and.returnValue(of(mockSearchResult))
     itemSearchServiceSpy.list.and.returnValue(of(mockListResult))
 
     forkJoin([
-      searchService.search(requestedItem).pipe(flatMap((result) => searchService.list(result, 10))),
+      searchService.searchOrExchange(requestedItem).pipe(flatMap((result) => searchService.list(result, 10))),
       currencyService.searchById('chaos'),
     ]).subscribe(
       (results) => {

--- a/src/app/shared/module/poe/service/item/item-search-analyze.service.spec.ts
+++ b/src/app/shared/module/poe/service/item/item-search-analyze.service.spec.ts
@@ -58,7 +58,7 @@ describe('ItemSearchAnalyzeService', () => {
   ]
 
   beforeEach((done) => {
-    const itemSearchServiceSpyObj = jasmine.createSpyObj('ItemSearchService', ['search', 'list'])
+    const itemSearchServiceSpyObj = jasmine.createSpyObj('ItemSearchService', ['searchOrExchange', 'list'])
 
     TestBed.configureTestingModule({
       imports: [SharedModule],

--- a/src/app/shared/module/poe/service/item/item-search-analyze.service.spec.ts
+++ b/src/app/shared/module/poe/service/item/item-search-analyze.service.spec.ts
@@ -1,4 +1,4 @@
-import { async, TestBed } from '@angular/core/testing'
+import { TestBed } from '@angular/core/testing'
 import { Item, Language } from '@shared/module/poe/type'
 import { SharedModule } from '@shared/shared.module'
 import { forkJoin, of } from 'rxjs'
@@ -8,7 +8,8 @@ import { BaseItemTypesService } from '../base-item-types/base-item-types.service
 import { ContextService } from '../context.service'
 import { CurrencyService } from '../currency/currency.service'
 import { ItemSearchAnalyzeService } from './item-search-analyze.service'
-import { ItemSearchService } from './item-search.service'
+import { ItemSearchListing, ItemSearchResult, ItemSearchService } from './item-search.service'
+import moment from 'moment'
 
 describe('ItemSearchAnalyzeService', () => {
   let sut: ItemSearchAnalyzeService
@@ -18,7 +19,7 @@ describe('ItemSearchAnalyzeService', () => {
   let baseItemTypesService: BaseItemTypesService
   let itemSearchServiceSpy: jasmine.SpyObj<ItemSearchService>
 
-  const mockSearchResult: any = {
+  const mockSearchResult: ItemSearchResult = {
     searchType: TradeSearchType.NormalTrade,
     id: 'y35jtR',
     hits: [
@@ -30,10 +31,10 @@ describe('ItemSearchAnalyzeService', () => {
     url: 'https://www.pathofexile.com/trade/search/Delirum/y35jtR',
   }
 
-  const mockListResult: any = [
+  const mockListResult: ItemSearchListing[] = [
     {
       seller: 'Lord_Mohamed',
-      indexed: '2020-06-12T13:49:07.000Z',
+      indexed: moment('2020-06-12T13:49:07.000Z'),
       currency: {
         id: 'jew',
         nameType: "Jeweller's Orb",
@@ -42,10 +43,12 @@ describe('ItemSearchAnalyzeService', () => {
       },
       amount: 1,
       age: '4 days ago',
+      priceNumerator: 1,
+      priceDenominator: 1,
     },
     {
       seller: 'Lord_Mohamed',
-      indexed: '2020-06-13T12:54:38.000Z',
+      indexed: moment('2020-06-13T12:54:38.000Z'),
       currency: {
         id: 'alch',
         nameType: 'Orb of Alchemy',
@@ -54,11 +57,16 @@ describe('ItemSearchAnalyzeService', () => {
       },
       amount: 1,
       age: '3 days ago',
+      priceNumerator: 1,
+      priceDenominator: 1,
     },
   ]
 
   beforeEach((done) => {
-    const itemSearchServiceSpyObj = jasmine.createSpyObj('ItemSearchService', ['searchOrExchange', 'list'])
+    const itemSearchServiceSpyObj = jasmine.createSpyObj('ItemSearchService', [
+      'searchOrExchange',
+      'list',
+    ])
 
     TestBed.configureTestingModule({
       imports: [SharedModule],
@@ -88,7 +96,9 @@ describe('ItemSearchAnalyzeService', () => {
     itemSearchServiceSpy.list.and.returnValue(of(mockListResult))
 
     forkJoin([
-      searchService.searchOrExchange(requestedItem).pipe(flatMap((result) => searchService.list(result, 10))),
+      searchService
+        .searchOrExchange(requestedItem)
+        .pipe(flatMap((result) => searchService.list(result, 10))),
       currencyService.searchById('chaos'),
     ]).subscribe(
       (results) => {

--- a/src/app/shared/module/poe/service/item/item-search-analyze.service.spec.ts
+++ b/src/app/shared/module/poe/service/item/item-search-analyze.service.spec.ts
@@ -3,11 +3,12 @@ import { Item, Language } from '@shared/module/poe/type'
 import { SharedModule } from '@shared/shared.module'
 import { forkJoin, of } from 'rxjs'
 import { flatMap } from 'rxjs/operators'
+import { TradeSearchType } from '@data/poe'
 import { BaseItemTypesService } from '../base-item-types/base-item-types.service'
 import { ContextService } from '../context.service'
 import { CurrencyService } from '../currency/currency.service'
 import { ItemSearchAnalyzeService } from './item-search-analyze.service'
-import { ItemSearchService, ItemSearchType } from './item-search.service'
+import { ItemSearchService } from './item-search.service'
 
 describe('ItemSearchAnalyzeService', () => {
   let sut: ItemSearchAnalyzeService
@@ -18,7 +19,7 @@ describe('ItemSearchAnalyzeService', () => {
   let itemSearchServiceSpy: jasmine.SpyObj<ItemSearchService>
 
   const mockSearchResult: any = {
-    searchType: ItemSearchType.Trade,
+    searchType: TradeSearchType.NormalTrade,
     id: 'y35jtR',
     hits: [
       '72fad07c5684c05f543504bf40c1739081e34a3c63f101b1c4477d8547763563',

--- a/src/app/shared/module/poe/service/item/item-search-analyze.service.spec.ts
+++ b/src/app/shared/module/poe/service/item/item-search-analyze.service.spec.ts
@@ -7,7 +7,7 @@ import { BaseItemTypesService } from '../base-item-types/base-item-types.service
 import { ContextService } from '../context.service'
 import { CurrencyService } from '../currency/currency.service'
 import { ItemSearchAnalyzeService } from './item-search-analyze.service'
-import { ItemSearchService } from './item-search.service'
+import { ItemSearchService, ItemSearchType } from './item-search.service'
 
 describe('ItemSearchAnalyzeService', () => {
   let sut: ItemSearchAnalyzeService
@@ -18,6 +18,7 @@ describe('ItemSearchAnalyzeService', () => {
   let itemSearchServiceSpy: jasmine.SpyObj<ItemSearchService>
 
   const mockSearchResult: any = {
+    searchType: ItemSearchType.Trade,
     id: 'y35jtR',
     hits: [
       '72fad07c5684c05f543504bf40c1739081e34a3c63f101b1c4477d8547763563',

--- a/src/app/shared/module/poe/service/item/item-search.service.spec.ts
+++ b/src/app/shared/module/poe/service/item/item-search.service.spec.ts
@@ -3,7 +3,7 @@ import { Item, Language } from '@shared/module/poe/type'
 import { SharedModule } from '@shared/shared.module'
 import { BaseItemTypesService } from '../base-item-types/base-item-types.service'
 import { ContextService } from '../context.service'
-import { ItemSearchService } from './item-search.service'
+import { ItemSearchService, ItemSearchType } from './item-search.service'
 import { TradeHttpService, TradeOrExchangeSearchResponse } from '@data/poe'
 import { of } from 'rxjs'
 
@@ -16,6 +16,7 @@ describe('ItemSearchService', () => {
   const mockLeagues: any = require('doc/poe/api_trade_data_leagues.json')
   const mockStatic: any = require('doc/poe/api_trade_data_static.json')
   const mockSearchResult: TradeOrExchangeSearchResponse = {
+    searchType: ItemSearchType.Trade,
     id: 'y35jtR',
     result: [
       '72fad07c5684c05f543504bf40c1739081e34a3c63f101b1c4477d8547763563',

--- a/src/app/shared/module/poe/service/item/item-search.service.spec.ts
+++ b/src/app/shared/module/poe/service/item/item-search.service.spec.ts
@@ -4,7 +4,7 @@ import { SharedModule } from '@shared/shared.module'
 import { BaseItemTypesService } from '../base-item-types/base-item-types.service'
 import { ContextService } from '../context.service'
 import { ItemSearchService } from './item-search.service'
-import { TradeHttpService, TradeOrExchangeSearchResponse, TradeSearchType } from '@data/poe'
+import { TradeFetchResult, TradeHttpService, TradeOrExchangeSearchResponse, TradeResponse, TradeSearchType } from '@data/poe'
 import { of } from 'rxjs'
 
 describe('ItemSearchService', () => {
@@ -25,221 +25,32 @@ describe('ItemSearchService', () => {
     total: 15785,
     url: 'https://www.pathofexile.com/trade/search/Delirum/y35jtR',
   }
-  const mockFetchResult = {
+  const mockFetchResult: TradeResponse<TradeFetchResult> = {
     result: [
       {
         id: '72fad07c5684c05f543504bf40c1739081e34a3c63f101b1c4477d8547763563',
         listing: {
-          method: 'psapi',
           indexed: '2020-06-12T13:49:07Z',
-          stash: { name: 'Valuable', x: 1, y: 1 },
-          whisper:
-            "@lord_mOHAMED_HERO Hi, I would like to buy your Sorrow Twirl Topaz Ring listed for 1 jew in Delirium (stash tab 'Valuable'; position: left 2, top 2)",
           account: {
             name: 'Lord_Mohamed',
-            lastCharacterName: 'lord_mOHAMED_HERO',
-            online: { league: 'Delirium' },
-            language: 'en_US',
           },
           price: { type: '~price', amount: 1, currency: 'jew' },
         },
         item: {
-          verified: true,
-          w: 1,
-          h: 1,
-          icon:
-            'https://web.poecdn.com/image/Art/2DItems/Rings/Ring5.png?w=1&h=1&scale=1&v=d645f9adfc012c52674c94d16b4292b2',
-          league: 'Delirium',
-          name: 'Sorrow Twirl',
-          typeLine: 'Topaz Ring',
-          identified: true,
-          ilvl: 14,
           note: '~price 1 jew',
-          requirements: [{ name: 'Level', values: [['12', 0]], displayMode: 0 }],
-          implicitMods: ['+26% to Lightning Resistance'],
-          explicitMods: [
-            'Adds 3 to 8 Cold Damage to Attacks',
-            'Adds 1 to 15 Lightning Damage to Attacks',
-            '+16 to maximum Life',
-            'Regenerate 2 Life per second',
-            '10% increased Rarity of Items found',
-            '+6% to Lightning Resistance',
-          ],
-          frameType: 2,
-          extended: {
-            mods: {
-              implicit: [
-                {
-                  name: '',
-                  tier: '',
-                  magnitudes: [{ hash: 'implicit.stat_1671376347', min: 20, max: 30 }],
-                },
-              ],
-              explicit: [
-                {
-                  name: 'Healthy',
-                  tier: 'P7',
-                  magnitudes: [{ hash: 'explicit.stat_3299347043', min: 10, max: 19 }],
-                },
-                {
-                  name: 'of the Cloud',
-                  tier: 'S8',
-                  magnitudes: [{ hash: 'explicit.stat_1671376347', min: 6, max: 11 }],
-                },
-                {
-                  name: 'Chilled',
-                  tier: 'P8',
-                  magnitudes: [
-                    {
-                      hash: 'explicit.stat_4067062424',
-                      min: 3,
-                      max: 4,
-                    },
-                    { hash: 'explicit.stat_4067062424', min: 7, max: 8 },
-                  ],
-                },
-                {
-                  name: 'of Plunder',
-                  tier: 'S4',
-                  magnitudes: [{ hash: 'explicit.stat_3917489142', min: 6, max: 10 }],
-                },
-                {
-                  name: 'Buzzing',
-                  tier: 'P8',
-                  magnitudes: [
-                    {
-                      hash: 'explicit.stat_1754445556',
-                      min: 1,
-                      max: 1,
-                    },
-                    { hash: 'explicit.stat_1754445556', min: 14, max: 15 },
-                  ],
-                },
-                {
-                  name: 'of the Newt',
-                  tier: 'S7',
-                  magnitudes: [{ hash: 'explicit.stat_3325883026', min: 1, max: 2 }],
-                },
-              ],
-            },
-            hashes: {
-              implicit: [['implicit.stat_1671376347', [0]]],
-              explicit: [
-                ['explicit.stat_4067062424', [2]],
-                ['explicit.stat_1754445556', [4]],
-                ['explicit.stat_3299347043', [0]],
-                ['explicit.stat_3325883026', [5]],
-                ['explicit.stat_3917489142', [3]],
-                ['explicit.stat_1671376347', [1]],
-              ],
-            },
-            text:
-              'UmFyaXR5OiBSYXJlDQpTb3Jyb3cgVHdpcmwNClRvcGF6IFJpbmcNCi0tLS0tLS0tDQpSZXF1aXJlbWVudHM6DQpMZXZlbDogMTINCi0tLS0tLS0tDQpJdGVtIExldmVsOiAxNA0KLS0tLS0tLS0NCisyNiUgdG8gTGlnaHRuaW5nIFJlc2lzdGFuY2UgKGltcGxpY2l0KQ0KLS0tLS0tLS0NCkFkZHMgMyB0byA4IENvbGQgRGFtYWdlIHRvIEF0dGFja3MNCkFkZHMgMSB0byAxNSBMaWdodG5pbmcgRGFtYWdlIHRvIEF0dGFja3MNCisxNiB0byBtYXhpbXVtIExpZmUNClJlZ2VuZXJhdGUgMiBMaWZlIHBlciBzZWNvbmQNCjEwJSBpbmNyZWFzZWQgUmFyaXR5IG9mIEl0ZW1zIGZvdW5kDQorNiUgdG8gTGlnaHRuaW5nIFJlc2lzdGFuY2UNCi0tLS0tLS0tDQpOb3RlOiB+cHJpY2UgMSBqZXcNCg==',
-          },
         },
       },
       {
         id: '71c98661168b99693db42191c4788f8216a335f095e49fa3d35c49fb200c0f5d',
         listing: {
-          method: 'psapi',
           indexed: '2020-06-13T12:54:38Z',
-          stash: { name: '~price', x: 9, y: 9 },
-          whisper:
-            "@lord_mOHAMED_HERO Hi, I would like to buy your Loath Coil Topaz Ring listed for 1 alch in Delirium (stash tab '~price'; position: left 10, top 10)",
           account: {
             name: 'Lord_Mohamed',
-            lastCharacterName: 'lord_mOHAMED_HERO',
-            online: { league: 'Delirium' },
-            language: 'en_US',
           },
           price: { type: '~price', amount: 1, currency: 'alch' },
         },
         item: {
-          verified: true,
-          w: 1,
-          h: 1,
-          icon:
-            'https://web.poecdn.com/image/Art/2DItems/Rings/Ring5.png?w=1&h=1&scale=1&v=d645f9adfc012c52674c94d16b4292b2',
-          league: 'Delirium',
-          name: 'Loath Coil',
-          typeLine: 'Topaz Ring',
-          identified: true,
-          ilvl: 70,
           note: '~price 1 alch',
-          requirements: [{ name: 'Level', values: [['52', 0]], displayMode: 0 }],
-          implicitMods: ['+23% to Lightning Resistance'],
-          explicitMods: [
-            '+42 to Dexterity',
-            'Adds 4 to 7 Physical Damage to Attacks',
-            'Adds 20 to 36 Fire Damage to Attacks',
-            '+5% to all Elemental Resistances',
-            '+26% to Cold Resistance',
-          ],
-          frameType: 2,
-          extended: {
-            mods: {
-              implicit: [
-                {
-                  name: '',
-                  tier: '',
-                  magnitudes: [{ hash: 'implicit.stat_1671376347', min: 20, max: 30 }],
-                },
-              ],
-              explicit: [
-                {
-                  name: 'Polished',
-                  tier: 'P4',
-                  magnitudes: [
-                    {
-                      hash: 'explicit.stat_3032590688',
-                      min: 3,
-                      max: 4,
-                    },
-                    { hash: 'explicit.stat_3032590688', min: 6, max: 7 },
-                  ],
-                },
-                {
-                  name: 'of the Crystal',
-                  tier: 'S5',
-                  magnitudes: [{ hash: 'explicit.stat_2901986750', min: 3, max: 5 }],
-                },
-                {
-                  name: 'of the Yeti',
-                  tier: 'S5',
-                  magnitudes: [{ hash: 'explicit.stat_4220027924', min: 24, max: 29 }],
-                },
-                {
-                  name: 'of the Jaguar',
-                  tier: 'S3',
-                  magnitudes: [{ hash: 'explicit.stat_3261801346', min: 38, max: 42 }],
-                },
-                {
-                  name: 'Blasting',
-                  tier: 'P2',
-                  magnitudes: [
-                    {
-                      hash: 'explicit.stat_1573130764',
-                      min: 16,
-                      max: 22,
-                    },
-                    { hash: 'explicit.stat_1573130764', min: 32, max: 38 },
-                  ],
-                },
-              ],
-            },
-            hashes: {
-              implicit: [['implicit.stat_1671376347', [0]]],
-              explicit: [
-                ['explicit.stat_3261801346', [3]],
-                ['explicit.stat_3032590688', [0]],
-                ['explicit.stat_1573130764', [4]],
-                ['explicit.stat_2901986750', [1]],
-                ['explicit.stat_4220027924', [2]],
-              ],
-            },
-            text:
-              'UmFyaXR5OiBSYXJlDQpMb2F0aCBDb2lsDQpUb3BheiBSaW5nDQotLS0tLS0tLQ0KUmVxdWlyZW1lbnRzOg0KTGV2ZWw6IDUyDQotLS0tLS0tLQ0KSXRlbSBMZXZlbDogNzANCi0tLS0tLS0tDQorMjMlIHRvIExpZ2h0bmluZyBSZXNpc3RhbmNlIChpbXBsaWNpdCkNCi0tLS0tLS0tDQorNDIgdG8gRGV4dGVyaXR5DQpBZGRzIDQgdG8gNyBQaHlzaWNhbCBEYW1hZ2UgdG8gQXR0YWNrcw0KQWRkcyAyMCB0byAzNiBGaXJlIERhbWFnZSB0byBBdHRhY2tzDQorNSUgdG8gYWxsIEVsZW1lbnRhbCBSZXNpc3RhbmNlcw0KKzI2JSB0byBDb2xkIFJlc2lzdGFuY2UNCi0tLS0tLS0tDQpOb3RlOiB+cHJpY2UgMSBhbGNoDQo=',
-          },
         },
       },
     ],
@@ -248,6 +59,7 @@ describe('ItemSearchService', () => {
   beforeEach((done) => {
     const tradeServiceSpyObj = jasmine.createSpyObj('TradeHttpService', [
       'search',
+      'exchange',
       'fetch',
       'getStats',
       'getStatic',
@@ -279,6 +91,7 @@ describe('ItemSearchService', () => {
       typeId: baseItemTypesService.search('Topaz Ring', 1),
     }
     tradeServiceSpy.search.and.returnValue(of(mockSearchResult))
+    tradeServiceSpy.exchange.and.returnValue(of(mockSearchResult))
 
     sut.searchOrExchange(requestedItem, { language: Language.English }).subscribe(
       (result) => {
@@ -296,6 +109,7 @@ describe('ItemSearchService', () => {
       typeId: baseItemTypesService.search('Topaz Ring', 1),
     }
     tradeServiceSpy.search.and.returnValue(of(mockSearchResult))
+    tradeServiceSpy.exchange.and.returnValue(of(mockSearchResult))
     tradeServiceSpy.fetch.and.returnValue(of(mockFetchResult))
     tradeServiceSpy.getStatic.and.returnValue(of(mockStatic))
 

--- a/src/app/shared/module/poe/service/item/item-search.service.spec.ts
+++ b/src/app/shared/module/poe/service/item/item-search.service.spec.ts
@@ -3,8 +3,8 @@ import { Item, Language } from '@shared/module/poe/type'
 import { SharedModule } from '@shared/shared.module'
 import { BaseItemTypesService } from '../base-item-types/base-item-types.service'
 import { ContextService } from '../context.service'
-import { ItemSearchService, ItemSearchType } from './item-search.service'
-import { TradeHttpService, TradeOrExchangeSearchResponse } from '@data/poe'
+import { ItemSearchService } from './item-search.service'
+import { TradeHttpService, TradeOrExchangeSearchResponse, TradeSearchType } from '@data/poe'
 import { of } from 'rxjs'
 
 describe('ItemSearchService', () => {
@@ -16,7 +16,7 @@ describe('ItemSearchService', () => {
   const mockLeagues: any = require('doc/poe/api_trade_data_leagues.json')
   const mockStatic: any = require('doc/poe/api_trade_data_static.json')
   const mockSearchResult: TradeOrExchangeSearchResponse = {
-    searchType: ItemSearchType.Trade,
+    searchType: TradeSearchType.Trade,
     id: 'y35jtR',
     result: [
       '72fad07c5684c05f543504bf40c1739081e34a3c63f101b1c4477d8547763563',

--- a/src/app/shared/module/poe/service/item/item-search.service.spec.ts
+++ b/src/app/shared/module/poe/service/item/item-search.service.spec.ts
@@ -4,7 +4,7 @@ import { SharedModule } from '@shared/shared.module'
 import { BaseItemTypesService } from '../base-item-types/base-item-types.service'
 import { ContextService } from '../context.service'
 import { ItemSearchService } from './item-search.service'
-import { TradeHttpService, TradeSearchResponse } from '@data/poe'
+import { TradeHttpService, TradeOrExchangeSearchResponse } from '@data/poe'
 import { of } from 'rxjs'
 
 describe('ItemSearchService', () => {
@@ -15,7 +15,7 @@ describe('ItemSearchService', () => {
 
   const mockLeagues: any = require('doc/poe/api_trade_data_leagues.json')
   const mockStatic: any = require('doc/poe/api_trade_data_static.json')
-  const mockSearchResult: TradeSearchResponse = {
+  const mockSearchResult: TradeOrExchangeSearchResponse = {
     id: 'y35jtR',
     result: [
       '72fad07c5684c05f543504bf40c1739081e34a3c63f101b1c4477d8547763563',
@@ -279,7 +279,7 @@ describe('ItemSearchService', () => {
     }
     tradeServiceSpy.search.and.returnValue(of(mockSearchResult))
 
-    sut.search(requestedItem, { language: Language.English }).subscribe(
+    sut.searchOrExchange(requestedItem, { language: Language.English }).subscribe(
       (result) => {
         expect(result.hits.length).toBeGreaterThan(0)
         done()
@@ -298,7 +298,7 @@ describe('ItemSearchService', () => {
     tradeServiceSpy.fetch.and.returnValue(of(mockFetchResult))
     tradeServiceSpy.getStatic.and.returnValue(of(mockStatic))
 
-    sut.search(requestedItem, { language: Language.English, leagueId: 'Delirium' }).subscribe(
+    sut.searchOrExchange(requestedItem, { language: Language.English, leagueId: 'Delirium' }).subscribe(
       (result) => {
         expect(result.hits.length).toBeGreaterThan(0)
 

--- a/src/app/shared/module/poe/service/item/item-search.service.spec.ts
+++ b/src/app/shared/module/poe/service/item/item-search.service.spec.ts
@@ -16,7 +16,7 @@ describe('ItemSearchService', () => {
   const mockLeagues: any = require('doc/poe/api_trade_data_leagues.json')
   const mockStatic: any = require('doc/poe/api_trade_data_static.json')
   const mockSearchResult: TradeOrExchangeSearchResponse = {
-    searchType: TradeSearchType.Trade,
+    searchType: TradeSearchType.NormalTrade,
     id: 'y35jtR',
     result: [
       '72fad07c5684c05f543504bf40c1739081e34a3c63f101b1c4477d8547763563',

--- a/src/app/shared/module/poe/service/item/item-search.service.ts
+++ b/src/app/shared/module/poe/service/item/item-search.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core'
 import { CacheService, LoggerService } from '@app/service'
-import { ExchangeSearchRequest, TradeFetchResult, TradeHttpService, TradeSearchRequest } from '@data/poe'
+import { ExchangeSearchRequest, TradeFetchResult, TradeHttpService, TradeSearchRequest, TradeSearchType } from '@data/poe'
 import { Currency, Item, ItemCategory, Language } from '@shared/module/poe/type'
 import moment from 'moment'
 import { forkJoin, from, Observable, of } from 'rxjs'
@@ -25,17 +25,12 @@ export interface ItemSearchListing {
 }
 
 export interface ItemSearchResult {
-  searchType: ItemSearchType
+  searchType: TradeSearchType
   id: string
   language: Language
   url: string
   total: number
   hits: string[]
-}
-
-export enum ItemSearchType {
-  Trade = 'search',
-  BulkExchange = 'exchange',
 }
 
 @Injectable({

--- a/src/app/shared/module/poe/service/item/item-search.service.ts
+++ b/src/app/shared/module/poe/service/item/item-search.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core'
 import { CacheService, LoggerService } from '@app/service'
-import { TradeFetchResult, TradeHttpService, TradeSearchRequest } from '@data/poe'
-import { Currency, Item, Language } from '@shared/module/poe/type'
+import { ExchangeSearchRequest, TradeFetchResult, TradeHttpService, TradeSearchRequest } from '@data/poe'
+import { Currency, Item, ItemCategory, Language } from '@shared/module/poe/type'
 import moment from 'moment'
 import { forkJoin, from, Observable, of } from 'rxjs'
 import { flatMap, map, mergeMap, toArray } from 'rxjs/operators'
 import { ItemSearchIndexed, ItemSearchOptions } from '../../type/search.type'
+import { BaseItemTypesService } from '../base-item-types/base-item-types.service'
 import { ContextService } from '../context.service'
 import { CurrencyService } from '../currency/currency.service'
 import { ItemSearchQueryService } from './query/item-search-query.service'
@@ -19,14 +20,22 @@ export interface ItemSearchListing {
   age: string
   currency: Currency
   amount: number
+  priceNumerator: number
+  priceDenominator: number
 }
 
 export interface ItemSearchResult {
+  searchType: ItemSearchType
   id: string
   language: Language
   url: string
   total: number
   hits: string[]
+}
+
+export enum ItemSearchType {
+  Trade = 'search',
+  BulkExchange = 'exchange',
 }
 
 @Injectable({
@@ -36,61 +45,34 @@ export class ItemSearchService {
   constructor(
     private readonly context: ContextService,
     private readonly currencyService: CurrencyService,
+    private readonly baseItemTypesServices: BaseItemTypesService,
     private readonly requestService: ItemSearchQueryService,
     private readonly tradeService: TradeHttpService,
     private readonly cache: CacheService,
     private readonly logger: LoggerService
   ) {}
 
-  public search(requestedItem: Item, options?: ItemSearchOptions): Observable<ItemSearchResult> {
+  public searchOrExchange(requestedItem: Item, options?: ItemSearchOptions, currency?: Currency): Observable<ItemSearchResult> {
     options = options || {}
     options.leagueId = options.leagueId || this.context.get().leagueId
     options.language = options.language || this.context.get().language
 
-    const request: TradeSearchRequest = {
-      sort: {
-        price: 'asc',
-      },
-      query: {
-        status: {
-          option: options.online ? 'online' : 'any',
-        },
-        filters: {
-          trade_filters: {
-            filters: {
-              sale_type: {
-                option: 'priced',
-              },
-            },
-          },
-        },
-        stats: [],
-      },
-    }
-
-    const { indexed } = options
-    if (indexed) {
-      request.query.filters.trade_filters.filters.indexed = {
-        option: indexed === ItemSearchIndexed.AnyTime ? null : indexed,
-      }
-    }
-
-    const { language, leagueId } = options
-    this.requestService.map(requestedItem, language, request.query)
-
-    return this.tradeService.search(request, language, leagueId).pipe(
-      map((response) => {
-        const { id, url, total } = response
-        const result: ItemSearchResult = {
-          id,
-          language,
-          url,
-          total,
-          hits: response.result || [],
+    switch (requestedItem.category) {
+      case ItemCategory.Currency:
+      case ItemCategory.CurrencyFossil:
+      case ItemCategory.CurrencyResonator:
+      case ItemCategory.CurrencyIncubator:
+      case ItemCategory.MapFragment:
+      case ItemCategory.MapScarab:
+      case ItemCategory.Card:
+        if (currency) {
+          return this.exchange(requestedItem, options, currency)
         }
-        return result
-      })
-    )
+        // fall-through
+
+      default:
+        return this.search(requestedItem, options)
+    }
   }
 
   public list(search: ItemSearchResult, fetchCount: number): Observable<ItemSearchListing[]> {
@@ -158,6 +140,94 @@ export class ItemSearchService {
     )
   }
 
+  private search(requestedItem: Item, options: ItemSearchOptions): Observable<ItemSearchResult> {
+    const request: TradeSearchRequest = {
+      sort: {
+        price: 'asc',
+      },
+      query: {
+        status: {
+          option: options.online ? 'online' : 'any',
+        },
+        filters: {
+          trade_filters: {
+            filters: {
+              sale_type: {
+                option: 'priced',
+              },
+            },
+          },
+        },
+        stats: [],
+      },
+    }
+
+    const { indexed } = options
+    if (indexed) {
+      request.query.filters.trade_filters.filters.indexed = {
+        option: indexed === ItemSearchIndexed.AnyTime ? null : indexed,
+      }
+    }
+
+    const { language, leagueId } = options
+    this.requestService.map(requestedItem, language, request.query)
+
+    return this.tradeService.search(request, language, leagueId).pipe(
+      map((response) => {
+        const { id, url, total } = response
+        const result: ItemSearchResult = {
+          searchType: response.searchType,
+          id,
+          language,
+          url,
+          total,
+          hits: response.result || [],
+        }
+        return result
+      })
+    )
+  }
+
+  private exchange(requestedItem: Item, options: ItemSearchOptions, currency: Currency): Observable<ItemSearchResult> {
+    const { online, language, leagueId } = options
+
+    return this.currencyService.searchByNameType(this.baseItemTypesServices.translate(requestedItem.typeId, language), language).pipe(
+      flatMap((requestedCurrency) => {
+        if (!requestedCurrency) {
+          return this.search(requestedItem, options)
+        }
+
+        const request: ExchangeSearchRequest = {
+          sort: {
+            price: 'asc',
+          },
+          exchange: {
+            status: {
+              option: online ? 'online' : 'any',
+            },
+            want: [requestedCurrency.id],
+            have: [currency.id]
+          }
+        }
+
+        return this.tradeService.exchange(request, language, leagueId).pipe(
+          map((response) => {
+            const { id, url, total } = response
+            const result: ItemSearchResult = {
+              searchType: response.searchType,
+              id,
+              language,
+              url,
+              total,
+              hits: response.result || [],
+            }
+            return result
+          })
+        )
+      })
+    )
+  }
+
   private mapResult(result: TradeFetchResult): Observable<ItemSearchListing> {
     if (
       !result ||
@@ -170,7 +240,7 @@ export class ItemSearchService {
       return of(undefined)
     }
 
-    const { listing } = result
+    const { listing, item } = result
 
     const indexed = moment(listing.indexed)
     if (!indexed.isValid()) {
@@ -191,6 +261,16 @@ export class ItemSearchService {
       return of(undefined)
     }
 
+    let priceNumerator = amount
+    let priceDenominator = 1
+
+    const { note } = item
+    const priceFraction = note?.replace(price.type, '').replace(price.currency, '').trim().split('/') || []
+    if (priceFraction.length == 2) {
+      priceNumerator = +priceFraction[0]
+      priceDenominator = +priceFraction[1]
+    }
+
     const currencyId = price.currency
     return this.currencyService.searchById(currencyId).pipe(
       map((currency) => {
@@ -204,6 +284,8 @@ export class ItemSearchService {
           currency,
           amount,
           age: indexed.fromNow(),
+          priceNumerator,
+          priceDenominator,
         }
       })
     )

--- a/src/assets/i18n/english.json
+++ b/src/assets/i18n/english.json
@@ -140,6 +140,7 @@
     "translate": "Evaluate Translate",
     "translate-language": "Translated Item Language",
     "translate-settings": "Evaluate Translate Settings",
+    "try-again": "Try again?",
     "value": "Value"
   },
   "help": {

--- a/src/spec_helper.spec.ts
+++ b/src/spec_helper.spec.ts
@@ -5,7 +5,7 @@ import { forkJoin } from 'rxjs'
 let cache: CacheService
 
 const mockLeagues: any = require('doc/poe/api_trade_data_leagues.json')
-const mockStaticData: any = require('doc/poe/mockCurrenciesCache.json')
+const mockStaticCurrencyData: any = require('doc/poe/mockCurrenciesCache.json')
 const mockExchangeRates: any = require('doc/poe-ninja/currencyoverviewcache.json')
 const mockItemCategoryProphecy: any = require('doc/poe-ninja/itemcategory_prophecy_cache.json')
 
@@ -14,7 +14,8 @@ beforeAll((done) => {
   forkJoin([
     cache.store(`leagues_1`, mockLeagues.result, 99999, true),
     cache.store('currency_chaos_equivalents_Delirium', mockExchangeRates, 99999, true),
-    cache.store('currencies_1', mockStaticData, 99999, true),
+    cache.store('all_1', mockStaticCurrencyData, 99999, true),
+    cache.store('currency_1', mockStaticCurrencyData, 99999, true),
     cache.store('item_category_Delirium_prophecy', mockItemCategoryProphecy, 99999, true),
   ]).subscribe(() => done())
 })


### PR DESCRIPTION
## Description

This PR adds functionality to contact the GGG bulk-exchange trade API.  
  
The evaluate-search component has been updated to make use of the new bulk-exchange API, given that the requested item falls in one of the "bulk exchange" categories _and_ is present in the PoE static trade data (which denotes all available bulk exchange items, split into different groups).  
  
With the use of bulk exchange, a new currency ratio frame was added to show fractions (as this occurs quite often in bulk exchange).  

### Additional Considerations

* Due to how bulk-exchange works, I've ignored the chart/graph part of the evaluate-search completely, and focused solely on the table/list part. Perhaps this bulk-exchange impl. could be extended to the graph in the future.
* Currently there is no way to "mix" the bulk-exchange results as only a single currency in the "I have" section is searched at a time. In a future feature update we could consider implementing the mixing and perhaps use the exchange rates to properly sort them.
* Currently there is no way to not-bulk-exchange search when an item is considered to be bulk-exchange-searchable. In a future update we could consider adding an option to switch between bulk-exchange and normal search. (Even if the mixed-results feature would be implemented, there still would be a limit to how many simultaneous currencies can be selected & searched using the bulk-exchange. Therefore having the option to switch might be beneficial in some cases as trades of "any" currency would be listed)

## Screenshots/Video

Some regular bulk-exchange results (using chaos -> chromatic):
![image](https://user-images.githubusercontent.com/4527188/111881723-2aca0a00-89b2-11eb-8869-dd3344defec7.png)

A bulk-exchange result of an item closer to a <1:1 and 1:1 and >1:1 ratio (using chaos -> annulment):
![image](https://user-images.githubusercontent.com/4527188/111881736-33224500-89b2-11eb-9ad2-952997d023ad.png)

A bulk exchange with Chaos and Exalted as Evaluate currencies (selected in the settings menu), where the search result was changed from the original/initial chaos search to the exalted search:
![image](https://user-images.githubusercontent.com/4527188/111881739-3ae1e980-89b2-11eb-8450-cc3f46d9ab38.png)

A non-currency (in this case Fragment) bulk-exchange result:
![image](https://user-images.githubusercontent.com/4527188/111881826-a330cb00-89b2-11eb-95f7-91f740646b54.png)

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
