### PR TITLE
Increased maximum memory for npm during build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile for Linux build automation.
 # 
-# Run with 'docker build -o release .' from the repo root.
+# Run with 'DOCKER_BUILDKIT=1 docker build -o release .' from the repo root.
 # 
 # Demonstrates developing PoE-Overlay on Linux and produces testable Linux
 # builds. Each step will be cached independently, so subsequent builds will be
@@ -35,6 +35,8 @@ COPY electron $codedir/electron
 COPY img $codedir/img
 COPY src $codedir/src
 
+# Since 0.7.11 npm default memory restriction is too small to build the overlay
+ENV NODE_OPTIONS=--max_old_space_size=4096
 # Install NodeJS dependencies/modules.
 RUN npm install
 

--- a/LINUXSETUP.md
+++ b/LINUXSETUP.md
@@ -14,7 +14,7 @@ After installing those three libraries you can simply execute ```npm install```.
 
 With ```npm start```, you'll start up the dev server as normal.
 
-Building a production .deb and .appImage package needs to be done via ```npm run electron:linux```.
+Starting with version 0.7.11 building a production .deb and .appImage package exceeds the default memory limit of npm, needs to be done via ```NODE_OPTIONS=--max_old_space_size=4096 npm run electron:linux```.
 
 ## Notes:
  


### PR DESCRIPTION
and updated the documentation for linux.


## Description
Fixes out of heap errors occurring while building on Linux or Docker after #v0.7.10

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
