### PR TITLE
clarify option to add image as bookmark

### DIFF
--- a/src/app/modules/bookmark/component/bookmark-settings/bookmark-settings.component.html
+++ b/src/app/modules/bookmark/component/bookmark-settings/bookmark-settings.component.html
@@ -32,5 +32,9 @@
     <button mat-raised-button (click)="onAddClick()" class="card-button">
       {{ 'bookmark.add' | translate }}
     </button>
+    <button mat-raised-button (click)="onAddFileClick()" class="card-button">
+      {{ 'bookmark.add-file' | translate }}
+    </button>
+    <input style="display: none;" #ghostInput type="file" (change)="onFileSelected($event)"/>
   </div>
 </div>

--- a/src/app/modules/bookmark/component/bookmark-settings/bookmark-settings.component.scss
+++ b/src/app/modules/bookmark/component/bookmark-settings/bookmark-settings.component.scss
@@ -12,4 +12,8 @@
 .card-button {
   padding: 16px;
   width: 100%;
+
+  + .card-button {
+    margin-top: 8px;
+  }
 }

--- a/src/app/modules/bookmark/component/bookmark-settings/bookmark-settings.component.ts
+++ b/src/app/modules/bookmark/component/bookmark-settings/bookmark-settings.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
+import { ChangeDetectionStrategy, Component, ElementRef, Input, TemplateRef, ViewChild } from '@angular/core'
 import { UserSettings, UserSettingsComponent } from 'src/app/layout/type'
 
 export interface BookmarkUserSettings extends UserSettings {
@@ -20,6 +20,8 @@ export interface BookmarkUserBookmark {
 export class BookmarkSettingsComponent implements UserSettingsComponent {
   @Input()
   public settings: BookmarkUserSettings
+  @ViewChild('ghostInput')
+  public input: ElementRef;
 
   public load(): void {
     // stub
@@ -27,6 +29,19 @@ export class BookmarkSettingsComponent implements UserSettingsComponent {
 
   public onAddClick(): void {
     this.addBookmark()
+  }
+
+  public onAddFileClick(): void {
+    (this.input.nativeElement as HTMLInputElement).click();
+  }
+
+  public onFileSelected(event: InputEvent): void {
+    const path = (event.target as HTMLInputElement).files.item(0).path;
+    this.settings.bookmarks.push({
+      url: `file:///${path}`,
+      shortcut: undefined,
+      external: false,
+    });
   }
 
   public onRemoveClick(index: number): void {

--- a/src/app/modules/bookmark/component/bookmark-settings/bookmark-settings.component.ts
+++ b/src/app/modules/bookmark/component/bookmark-settings/bookmark-settings.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, Input, TemplateRef, ViewChild } from '@angular/core'
+import { ChangeDetectionStrategy, Component, ElementRef, Input, ViewChild } from '@angular/core'
 import { UserSettings, UserSettingsComponent } from 'src/app/layout/type'
 
 export interface BookmarkUserSettings extends UserSettings {

--- a/src/assets/i18n/english.json
+++ b/src/assets/i18n/english.json
@@ -13,7 +13,8 @@
     "add": "Add Bookmark",
     "external": "External",
     "name": "Bookmark",
-    "url": "Url"
+    "url": "Url",
+    "add-file": "Add File"
   },
   "clipboard": {
     "empty": "Clipboard was empty. You may need to start PoE Overlay with privileged rights.",

--- a/src/assets/i18n/english.json
+++ b/src/assets/i18n/english.json
@@ -11,10 +11,10 @@
   },
   "bookmark": {
     "add": "Add Bookmark",
+    "add-file": "Add File",
     "external": "External",
     "name": "Bookmark",
-    "url": "Url",
-    "add-file": "Add File"
+    "url": "Url"
   },
   "clipboard": {
     "empty": "Clipboard was empty. You may need to start PoE Overlay with privileged rights.",


### PR DESCRIPTION
The ability to add a local image as a bookmark already existed, but it was unclear that it was possible or how to do so.

This UI adds a file picker 1 click away and sets the path correctly automatically for the user.