### PR TITLE
Linux bugfixes

### DIFF
--- a/electron/game.ts
+++ b/electron/game.ts
@@ -1,5 +1,6 @@
 import { IpcMain, Rectangle } from 'electron'
 import * as path from 'path'
+import { procfs } from '@stroncium/procfs'
 import { GameLogListener, OnLogLineAddedFunc } from './game-log-listener'
 import { getActiveWindow, Window } from './window'
 
@@ -22,16 +23,14 @@ const POE_NAMES = [
   'pathofexile_x64',
   'pathofexile',
 
-  // Linux
-  'wine64-preloader',
-]
-
-const POE_KOREAN_NAMES = [
   // Kakao Client (Korean)
   'pathofexile_x64_kg.exe',
   'pathofexile_kg.exe',
   'pathofexile_x64_kg',
   'pathofexile_kg',
+
+  // Linux
+  'wine64-preloader',
 ]
 
 const POE_TITLES = ['Path of Exile']
@@ -54,15 +53,7 @@ export class Game {
 
     const window = await getActiveWindow()
     if (window) {
-      const windowPath = (window.path || '').toLowerCase()
-      const name = path.basename(windowPath)
-      if (POE_NAMES.includes(name)) {
-        this.updateWindow(window, "Client.txt")
-      } else if (POE_KOREAN_NAMES.includes(name)) {
-        this.updateWindow(window, "KakaoClient.txt")
-      } else {
-        this.active = false
-      }
+      this.updateWindow(window)
     } else {
       this.active = false
     }
@@ -83,13 +74,35 @@ export class Game {
     })
   }
 
-  private updateWindow(window: Window, logFileName: string): void {
-    const title = window.title()
-    if (POE_TITLES.includes(title) || POE_ALTERNATIVE_TITLES.some((x) => title.startsWith(x))) {
-      this.window = window
-      this.active = true
-      this.bounds = window.bounds()
-      this.gameLogListener.setLogFilePath(path.join(path.parse(window.path).dir, "logs", logFileName))
+  private updateWindow(window: Window): void {
+
+    const windowPath = path.parse((window.path || '').toLowerCase())
+
+    if (POE_NAMES.includes(windowPath.base)) {
+      const title = window.title()
+      if (POE_TITLES.includes(title) || POE_ALTERNATIVE_TITLES.some((x) => title.startsWith(x))) {
+
+        this.window = window
+        this.active = true
+        this.bounds = window.bounds()
+
+        const isLinux = process.platform !== ('win32' || 'darwin')
+
+        var poeDir
+        if (!isLinux) {
+          poeDir = windowPath.dir
+        } else {
+          // This assumes the games is started through steam. Get POE directory from wine process env variable PWD.
+          poeDir = (new Map(procfs.processEnviron(window.processId))).get('PWD')
+        }
+
+        // Kakao client uses a different logfile name
+        const logFileName = windowPath.name.endsWith('_kg') ? "KakaoClient.txt" : "Client.txt"
+
+        this.gameLogListener.setLogFilePath(path.join(poeDir, "logs", logFileName))
+      } else {
+        this.active = false
+      }
     } else {
       this.active = false
     }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@angular/platform-browser-dynamic": "^9.1.3",
     "@angular/router": "^9.1.3",
     "@ngx-translate/core": "^12.1.2",
+    "@stroncium/procfs": "^1.2.1",
     "@swimlane/ngx-charts": "^13.0.4",
     "@types/resize-observer-browser": "^0.1.3",
     "active-win": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "moment": "^2.24.0",
     "ngx-color-picker": "^9.1.0",
     "node-window-manager": "^2.2.2",
-    "robotjs": "git+https://github.com/PoE-Overlay-Community/robotjs.git#a219829c83ff7f3a802c98a9c52a672ca798d80e",
+    "robotjs": "git+https://github.com/octalmage/robotjs.git#8ae87a91f06f49559f0db387bc2bd1ea01419880",
     "rxjs": "^6.5.5",
     "tslib": "^1.11.1",
     "zone.js": "^0.10.3"

--- a/src/app/core/service/input/keyboard.service.ts
+++ b/src/app/core/service/input/keyboard.service.ts
@@ -3,14 +3,14 @@ import { ElectronProvider } from '@app/provider'
 import { IpcRenderer } from 'electron'
 
 export enum KeyCode {
-  VK_KEY_C = 0x43,
-  VK_KEY_F = 0x46,
-  VK_KEY_V = 0x56,
-  VK_RETURN = 0x0d,
-  VK_LMENU = 0xa4,
-  VK_RMENU = 0xa5,
-  VK_LEFT = 0x25,
-  VK_RIGHT = 0x27,
+  VK_KEY_C = 'c',
+  VK_KEY_F = 'f',
+  VK_KEY_V = 'v',
+  VK_RETURN = 'enter',
+  VK_LMENU = 'alt',
+  VK_RMENU = 'right_alt',
+  VK_LEFT = 'left',
+  VK_RIGHT = 'right',
 }
 
 @Injectable({

--- a/src/app/modules/command/service/command.service.ts
+++ b/src/app/modules/command/service/command.service.ts
@@ -12,6 +12,10 @@ interface Command {
   send: boolean
 }
 
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -42,20 +46,22 @@ export class CommandService {
     this.command$
       .pipe(
         throttleTime(350),
-        map((command) => {
+        map(async (command) => {
           const text = this.clipboard.readText()
           this.clipboard.writeText(command.text)
+          await sleep(75)
           this.keyboard.setKeyboardDelay(5)
           this.keyboard.keyTap(KeyCode.VK_RETURN)
           this.keyboard.keyTap(KeyCode.VK_KEY_V, ['control'])
           if (command.send) {
+            await sleep(75)
             this.keyboard.keyTap(KeyCode.VK_RETURN)
           }
           return text
         }),
         delay(200),
-        tap((text) => {
-          this.clipboard.writeText(text)
+        tap(async (text) => {
+          this.clipboard.writeText(await text)
         })
       )
       .subscribe()


### PR DESCRIPTION
## Description

Multiple bugfixes for linux : 
* A windows specific keycode was sent for enter. Switched to the original robotjs lib to be able to use abstract key names
* Keystrokes were sent to quickly, causing some not to be registered. Added 2 75ms delay between keystrokes.
* Client.txt was not found as the binary running is wine_preloader. Added logic to retrieve the PoE directory from the wine environment. Cleaned up the game detection code. 

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [ ] ran `npm run ng:test`
- [ ] added unit tests
- [x] manually tested
