### PR TITLE
Improve copying price strings for bulk items

### DIFF
--- a/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-search-table/evaluate-search-table.component.ts
@@ -15,6 +15,8 @@ interface Row {
 
 interface SelectEvent {
   amount: number
+  numerator: number
+  denominator: number
   currency?: Currency
 }
 
@@ -78,6 +80,8 @@ export class EvaluateSearchTableComponent {
 
     this.amountSelect.next({
       amount: this.original ? row.originalAmount : row.amount,
+      numerator: row.priceNumerator,
+      denominator: row.priceDenominator,
       currency: this.original ? row.originalCurrency : undefined,
     })
   }

--- a/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.html
+++ b/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.html
@@ -78,7 +78,7 @@
                   [result]="result"
                   [original]="settings.evaluateCurrencyOriginal"
                   [wideViewport]="useWideViewport()"
-                  (amountSelect)="onAmountSelect($event.amount, $event.currency)"
+                  (amountSelect)="onAmountSelect($event.amount, $event.currency, $event.numerator, $event.denominator)"
                 >
                 </app-evaluate-search-table>
               </ng-container>

--- a/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-search/evaluate-search.component.ts
@@ -144,9 +144,9 @@ export class EvaluateSearchComponent implements OnInit, OnDestroy {
     }
   }
 
-  public onAmountSelect(amount: number, currency?: Currency): void {
+  public onAmountSelect(amount: number, currency?: Currency, numerator?: number, denominator?: number): void {
     currency = currency || this.result$.value.currency
-    this.evaluateResult.next({ amount, currency })
+    this.evaluateResult.next({ amount, currency, numerator: numerator, denominator: denominator })
   }
 
   public useWideViewport(): boolean {

--- a/src/app/shared/module/poe/service/stash/stash.service.ts
+++ b/src/app/shared/module/poe/service/stash/stash.service.ts
@@ -34,6 +34,8 @@ export interface StashPriceTag {
   currency: Currency
   type?: StashPriceTagType
   count?: number
+  numerator?: number
+  denominator?: number
 }
 
 @Injectable({
@@ -134,7 +136,7 @@ export class StashService {
 
   public copyPrice(tag: StashPriceTag): void {
     this.clipboard.writeText(
-      `${tag.type} ${tag.count ? `${tag.amount}/${tag.count}` : tag.amount} ${tag.currency.id}`
+      `${tag.type} ${tag.denominator > 1 ? `${tag.numerator}/${tag.denominator}` : tag.amount} ${tag.currency.id}`
     )
   }
 


### PR DESCRIPTION
When using the evaluate module and clicking on another
person's price listing to copy the price, if the price
is a fraction it currently copies as a decimal number, ie:
0.125.  However if you list it as such, listing services will
round it to 0.5.  Further, depending on the fraction, it
can be hard to reason about as a user on how many that
really represents per unit of currency.

This patch modifies the copied text to instead contain
the pervasive fractional numerator/denominator formatting for
any price that has a denominator greater than 1.

## Description

<!-- Summary of the changes -->

## Replication Steps

1. ctl-D on a bulk currency item
2. Find a listing that is a fraction
3. Click the listing
4. You should now get pricing text with a fraction ie X/Y rather than .025

## Screenshots/Video

<!--  Any screenshots or video of changes  -->

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [X] ran `npm run ng:test`
- [ ] added unit tests
- [X] manually tested
