### PR TITLE
Add a search icon to highlight item(s) in stash

### DIFF
--- a/src/app/modules/trade-companion/component/trade-notification/trade-notification.component.html
+++ b/src/app/modules/trade-companion/component/trade-notification/trade-notification.component.html
@@ -16,6 +16,7 @@
         <mat-icon class="incomingArrow" matTooltip="{{ 'trade-companion.trade-notification.incoming-trade' | translate }}">forward</mat-icon>
         <ng-container *ngTemplateOutlet="offerAndTimeTemplate"></ng-container>
         <mat-icon class="inviteToParty clickable" (click)="inviteToPartyClick()" matTooltip="{{ 'trade-companion.trade-notification.invite-to-party' | translate }}">add_circle_outline</mat-icon>
+        <mat-icon class="highlight clickable" (click)="highlightClick()" matTooltip="{{ 'trade-companion.trade-notification.highlight' | translate }}">search</mat-icon>
         <ng-container *ngTemplateOutlet="requestTradeTemplate"></ng-container>
         <mat-icon class="kickFromParty clickable" (click)="kickFromPartyClick()" matTooltip="{{ 'trade-companion.trade-notification.kick-from-party' | translate }}">remove_circle_outline</mat-icon>
       </ng-container>

--- a/src/app/modules/trade-companion/component/trade-notification/trade-notification.component.scss
+++ b/src/app/modules/trade-companion/component/trade-notification/trade-notification.component.scss
@@ -87,6 +87,10 @@ $text-padding: 1px;
       color: $lime-green;
     }
 
+    .highlight {
+      color: $broken-white;
+    }
+
     .requestTrade {
       color: $gold;
     }

--- a/src/app/modules/trade-companion/component/trade-notification/trade-notification.component.ts
+++ b/src/app/modules/trade-companion/component/trade-notification/trade-notification.component.ts
@@ -15,6 +15,7 @@ import { ColorUtils } from '@app/class'
 import { AppTranslateService } from '@app/service'
 import { CommandService } from '@modules/command/service/command.service'
 import { SnackBarService } from '@shared/module/material/service'
+import { StashService } from '@shared/module/poe/service'
 import { PoEAccountService } from '@shared/module/poe/service/account/account.service'
 import { TradeCompanionStashGridService } from '@shared/module/poe/service/trade-companion/trade-companion-stash-grid.service'
 import {
@@ -85,6 +86,7 @@ export class TradeNotificationComponent implements OnInit, OnDestroy, OnChanges 
     private readonly ref: ChangeDetectorRef,
     private readonly translate: AppTranslateService,
     private readonly accountService: PoEAccountService,
+    private readonly stashService: StashService,
   ) {}
 
   public ngOnInit(): void {
@@ -192,6 +194,11 @@ export class TradeNotificationComponent implements OnInit, OnDestroy, OnChanges 
     }
   }
 
+  public highlightClick(): void {
+    this.buttonClickAudioClip?.play()
+    this.highlight()
+  }
+
   public kickFromPartyClick(): void {
     this.buttonClickAudioClip?.play()
     this.kickFromParty()
@@ -289,6 +296,26 @@ export class TradeNotificationComponent implements OnInit, OnDestroy, OnChanges 
   private kickFromParty(): void {
     this.commandService.command(`/kick ${this.notification.playerName}`, this.settings)
     this.dismiss()
+  }
+
+  private highlight(): void {
+    if (this.notification.itemLocation != null) {
+      this.stashService.highlight(`pos:${this.notification.itemLocation.bounds.x},${this.notification.itemLocation.bounds.y}`).subscribe()
+    } else {
+      let highlightText = this.notification.item
+      if (typeof highlightText === 'object') {
+        highlightText = highlightText.currency.nameType
+      }
+
+      // Is the item a map?  If so, parse the tier out and use it to constrain the highlight
+      const mapRegex = /^(?<item>.*) \(T(?<tier>\d+)\)?/;
+      if (mapRegex.test(highlightText)) {
+        let match = mapRegex.exec(highlightText)
+        this.stashService.highlight(match.groups.item, `tier:${match.groups.tier}`).subscribe()
+      } else {
+        this.stashService.highlight(highlightText).subscribe()
+      }
+    }
   }
 
   private toggleItemHighlight(): void {

--- a/src/app/shared/module/poe/service/stash/stash.service.ts
+++ b/src/app/shared/module/poe/service/stash/stash.service.ts
@@ -107,9 +107,9 @@ export class StashService {
     return relativePointX >= 0 && relativePointX <= stashWidth
   }
 
-  public highlight(term: string): Observable<void> {
+  public highlight(term: string, unquotedTerm?: string): Observable<void> {
     const text = this.clipboard.readText()
-    this.clipboard.writeText(`"${term}"`)
+    this.clipboard.writeText(`"${term}"${(unquotedTerm) ? ` ${unquotedTerm}` : ``}`)
 
     this.keyboard.setKeyboardDelay(1)
     this.keyboard.keyToggle(KeyCode.VK_LMENU, false)
@@ -121,6 +121,7 @@ export class StashService {
       tap(() => this.keyboard.keyTap(KeyCode.VK_KEY_F, ['control'])),
       delay(175),
       tap(() => this.keyboard.keyTap(KeyCode.VK_KEY_V, ['control'])),
+      tap(() => this.keyboard.keyTap(KeyCode.VK_RETURN)),
       tap(() => this.shortcut.enableAllByAccelerator('CmdOrCtrl + F')),
       delay(75),
       tap(() => this.clipboard.writeText(text))

--- a/src/assets/i18n/english.json
+++ b/src/assets/i18n/english.json
@@ -396,6 +396,7 @@
       "elapsed-seconds": "{{seconds}}s",
       "expand": "Expand",
       "go-to-player-hideout": "Go to Player Hideout",
+      "highlight": "Highlight item in the stash",
       "incoming-trade": "Incoming Trade",
       "invite-to-party": "Invite to Party",
       "keybindings": {


### PR DESCRIPTION
This commit adds a search button that when clicked will
highlight the requested trade item(s) in the stash.

## Description

As described in the commit message, when you click the search icon it will copy the item's position (if known) or name into the highlight box for the stash.

## Replication Steps

<!-- Step by step instructions to replicate -->

## Screenshots/Video
![image](https://user-images.githubusercontent.com/107007/188248675-540cea25-c1f1-4d25-89b6-081b1e92c77a.png)

## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [ ] ran `npm run format`
- [X] ran `npm run ng:test`
- [ ] added unit tests
- [X] manually tested
