### PR TITLE
Updated Evaluate Options and Settings 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.40 (2025-11-24)
+
+- Added support to evaluate items using Instant Buyout only.
+
 ## 0.8.39 (2025-11-07)
 
 - Updated the PoE Assets using PoE Asset Updater (commit a25d8a4) and PoE Client v3.27.0b (hotfix 3)
@@ -71,10 +75,8 @@
   - Splitted the item links & socket count default/auto selection setting when evaluating
   - When sockets are auto evaluated (based on the sockets evaluation setting), only the number of sockets are evaluated;  
     Unless any of the following conditions are met:
-    - The item is corrupted -> all socket colors are taken into account
-	- The socket is a white socket -> the color for this specific socket is taken into account
-	- The item has any of the pre-determined stats that have special interactions with sockets -> all socket colors are taken into account  
-	  (Pre-determined stats are related to specific uniques such as "Dialla's Malefaction", "Skin of the Lords/Loyal", "Prismatic Eclipse", "Triad Grip", "Scaeva", "The Pariah" and "Crown of the Tyrant")
+    - The item is corrupted -> all socket colors are taken into account - The socket is a white socket -> the color for this specific socket is taken into account - The item has any of the pre-determined stats that have special interactions with sockets -> all socket colors are taken into account  
+       (Pre-determined stats are related to specific uniques such as "Dialla's Malefaction", "Skin of the Lords/Loyal", "Prismatic Eclipse", "Triad Grip", "Scaeva", "The Pariah" and "Crown of the Tyrant")
 
 ## 0.8.29 (2023-12-09)
 

--- a/src/app/modules/evaluate/component/evaluate-dialog/evaluate-dialog.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-dialog/evaluate-dialog.component.ts
@@ -56,13 +56,13 @@ export class EvaluateDialogComponent implements OnInit, AfterViewInit, OnDestroy
     private readonly evaluateQueryItemProvider: EvaluateQueryItemProvider,
     private readonly currencyService: CurrencyService,
     private readonly leagueService: LeaguesService,
-  ) {}
+  ) { }
 
   public ngOnInit(): void {
     const { settings, item } = this.data
     this.options = {
       indexed: settings.evaluateQueryIndexedRange,
-      online: settings.evaluateQueryOnline,
+      status: settings.evaluateQueryTradeType,
       leagueId: settings.leagueId,
       fetchCount: settings.evaluateQueryFetchCount,
     }

--- a/src/app/modules/evaluate/component/evaluate-options/evaluate-options.component.html
+++ b/src/app/modules/evaluate/component/evaluate-options/evaluate-options.component.html
@@ -19,14 +19,19 @@
       <span class="divider"></span>
     </ng-container>
 
-    <!-- online -->
-    <mat-slide-toggle
-      [(ngModel)]="options.online"
-      (ngModelChange)="onToggleOnlineClick()"
-      labelPosition="before"
-    >
-      {{ 'evaluate.search.online-only' | translate }}</mat-slide-toggle
-    >
+    <!-- status -->
+    <div class="row">
+        <button mat-icon-button (click)="changeStatus(-1)">
+          <mat-icon>keyboard_arrow_left</mat-icon>
+        </button>
+        <span class="option" (wheel)="onStatusWheel($event)">
+          {{ 'evaluate.search.status.' + getStatusText() | translate }}
+        </span>
+        <button mat-icon-button (click)="changeStatus(1)">
+          <mat-icon>keyboard_arrow_right</mat-icon>
+        </button>
+      </div>
+    
     <!-- indexed -->
     <ng-container *ngIf="options.indexed">
       <div class="row">

--- a/src/app/modules/evaluate/component/evaluate-options/evaluate-options.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-options/evaluate-options.component.ts
@@ -8,12 +8,12 @@ import {
 } from '@angular/core'
 import { LeaguesService } from '@shared/module/poe/service'
 import { League } from '@shared/module/poe/type'
-import { ItemSearchIndexed } from '@shared/module/poe/type/search.type'
+import { ItemSearchIndexed, ItemSearchStatus } from '@shared/module/poe/type/search.type'
 import { BehaviorSubject, Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 export interface EvaluateOptions {
-  online: boolean
+  status: ItemSearchStatus
   indexed: ItemSearchIndexed
   leagueId: string
   fetchCount: number
@@ -45,7 +45,7 @@ export class EvaluateOptionsComponent implements OnInit {
   public leagues$: Observable<LeagueMap>
   public isOpen = false
 
-  constructor(private readonly leagues: LeaguesService) {}
+  constructor(private readonly leagues: LeaguesService) { }
 
   public ngOnInit(): void {
     this.leagues$ = this.leagues.getLeagues().pipe(
@@ -92,6 +92,12 @@ export class EvaluateOptionsComponent implements OnInit {
     this.changeIndex(factor)
   }
 
+  public onStatusWheel(event: WheelEvent): void {
+    const factor = event.deltaY > 0 ? -1 : 1
+
+    this.changeStatus(factor)
+  }
+
   public changeIndex(factor: number): void {
     const keys = Object.getOwnPropertyNames(ItemSearchIndexed)
 
@@ -106,6 +112,23 @@ export class EvaluateOptionsComponent implements OnInit {
 
     const key = keys[index]
     this.options.indexed = ItemSearchIndexed[key]
+    this.optionsChange.emit(this.options)
+  }
+
+  public changeStatus(factor: number): void {
+    // Given the index of the enum, just go up or down by factor
+    const keys = Object.getOwnPropertyNames(ItemSearchStatus)
+    let index = keys.findIndex((x) => ItemSearchStatus[x] === this.options.status)
+    index += factor
+
+    if (index >= keys.length) {
+      index = 0
+    } else if (index < 0) {
+      index = keys.length - 1
+    }
+
+    const key = keys[index]
+    this.options.status = ItemSearchStatus[key]
     this.optionsChange.emit(this.options)
   }
 
@@ -135,6 +158,10 @@ export class EvaluateOptionsComponent implements OnInit {
 
   public getIndexedText(): string {
     return this.options.indexed.replace(/\d/, '')
+  }
+
+  getStatusText(): string {
+    return this.options.status
   }
 
   public openClose(): void {

--- a/src/app/modules/evaluate/component/evaluate-settings/evaluate-settings.component.html
+++ b/src/app/modules/evaluate/component/evaluate-settings/evaluate-settings.component.html
@@ -174,12 +174,15 @@
       <div class="profile">
         <mat-card>
           <mat-label>{{ 'evaluate.search.filter' | translate }}</mat-label>
-          <div class="toggle">
-            <mat-slide-toggle [checked]="settings.evaluateQueryOnline"
-                              (change)="settings.evaluateQueryOnline = $event.checked">
-              {{ 'evaluate.search.online-only' | translate }}
-            </mat-slide-toggle>
-          </div>
+          <mat-form-field>
+            <mat-label>{{ 'evaluate.search.trade-type' | translate }}</mat-label>
+            <mat-select [(value)]="settings.evaluateQueryTradeType">
+              <mat-option value="any"> {{ 'evaluate.search.status.any' | translate }} </mat-option>
+              <mat-option value="available"> {{ 'evaluate.search.status.available' | translate }} </mat-option>
+              <mat-option value="online"> {{ 'evaluate.search.status.online' | translate }} </mat-option>
+              <mat-option value="securable"> {{ 'evaluate.search.status.securable' | translate }} </mat-option>
+            </mat-select>
+          </mat-form-field>
           <mat-form-field>
             <mat-label>{{ 'evaluate.search.max-age.title' | translate }}</mat-label>
             <mat-select [(value)]="settings.evaluateQueryIndexedRange">

--- a/src/app/modules/evaluate/component/evaluate-settings/evaluate-settings.component.ts
+++ b/src/app/modules/evaluate/component/evaluate-settings/evaluate-settings.component.ts
@@ -8,7 +8,7 @@ import { StatsProvider } from '@shared/module/poe/provider/stats.provider'
 import { StatsService } from '@shared/module/poe/service'
 import { CurrencyService } from '@shared/module/poe/service/currency/currency.service'
 import { Currency, Language, StatType } from '@shared/module/poe/type'
-import { ItemSearchIndexed } from '@shared/module/poe/type/search.type'
+import { ItemSearchIndexed, ItemSearchStatus } from '@shared/module/poe/type/search.type'
 import { BehaviorSubject } from 'rxjs'
 import { UserSettings, UserSettingsComponent } from 'src/app/layout/type'
 
@@ -47,7 +47,7 @@ export interface EvaluateUserSettings extends UserSettings {
   evaluateQueryDefaultStatsEnchants: boolean
   evaluateQueryDefaultStatsModIcon: boolean
   evaluateQueryPostProcessClusterJewels: boolean
-  evaluateQueryOnline: boolean
+  evaluateQueryTradeType: ItemSearchStatus
   evaluateQueryIndexedRange: ItemSearchIndexed
   evaluateModifierMinRange: number
   evaluateModifierMaxRange: number
@@ -79,6 +79,7 @@ export class EvaluateSettingsComponent implements UserSettingsComponent {
   public languages = new EnumValues(Language)
   public views = new EnumValues(EvaluateResultView)
   public pricings = new EnumValues(EvaluatePricing)
+  public stasuses = Object.values(ItemSearchStatus)
 
   @Input()
   public settings: EvaluateUserSettings
@@ -97,13 +98,14 @@ export class EvaluateSettingsComponent implements UserSettingsComponent {
   public displayWithCount = (value: number) => `${value} items`
   public displayWithStat = (value: number) => (value === 50 ? '#' : value)
 
+
   constructor(
     private readonly currencyService: CurrencyService,
     private readonly statsProvider: StatsProvider,
     private readonly statsService: StatsService,
     private readonly clipboard: ClipboardService,
     private readonly snackbar: SnackBarService
-  ) {}
+  ) { }
 
   public load(): void {
     if (this.settings.language) {

--- a/src/app/modules/evaluate/evaluate.module.ts
+++ b/src/app/modules/evaluate/evaluate.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core'
 import { FEATURE_MODULES } from '@app/token'
 import { Feature, FeatureModule } from '@app/type'
 import { Language } from '@shared/module/poe/type'
-import { ItemSearchIndexed } from '@shared/module/poe/type/search.type'
+import { ItemSearchIndexed, ItemSearchStatus } from '@shared/module/poe/type/search.type'
 import { SharedModule } from '@shared/shared.module'
 import { UserSettingsFeature } from 'src/app/layout/type'
 import { EvaluateDialogComponent } from './component/evaluate-dialog/evaluate-dialog.component'
@@ -37,7 +37,7 @@ import { EvaluatePricePredictionComponent } from './component/evaluate-price-pre
   imports: [SharedModule],
 })
 export class EvaluateModule implements FeatureModule {
-  constructor(private readonly evaluateService: EvaluateService) {}
+  constructor(private readonly evaluateService: EvaluateService) { }
 
   public getSettings(): UserSettingsFeature {
     const defaultSettings: EvaluateUserSettings = {
@@ -80,7 +80,7 @@ export class EvaluateModule implements FeatureModule {
       evaluateQueryDefaultStatsModIcon: true,
       evaluateQueryPostProcessClusterJewels: true,
       evaluateQueryIndexedRange: ItemSearchIndexed.UpTo3DaysAgo,
-      evaluateQueryOnline: true,
+      evaluateQueryTradeType: ItemSearchStatus.Securable,
       evaluateQueryDebounceTime: 10,
       evaluateQueryFetchCount: 30,
       evaluateModifierMinRange: 10,

--- a/src/app/shared/module/poe/service/item/item-search.service.ts
+++ b/src/app/shared/module/poe/service/item/item-search.service.ts
@@ -212,7 +212,7 @@ export class ItemSearchService {
       },
       query: {
         status: {
-          option: options.online ? ItemSearchStatus.Available : ItemSearchStatus.Any,
+          option: options.status,
         },
         filters: {
           trade_filters: {
@@ -258,7 +258,7 @@ export class ItemSearchService {
     options: ItemSearchOptions,
     currency: Currency
   ): Observable<ItemSearchResult> {
-    const { online, language, leagueId } = options
+    const { status, language, leagueId } = options
 
     return this.currencyService
       .searchByNameType(
@@ -276,7 +276,7 @@ export class ItemSearchService {
             engine: ExchangeEngine.New,
             exchange: {
               status: {
-                option: online ? 'online' : 'any',
+                option: status,
               },
               want: [requestedCurrency.id],
               have: [currency.id],

--- a/src/app/shared/module/poe/type/search.type.ts
+++ b/src/app/shared/module/poe/type/search.type.ts
@@ -10,16 +10,17 @@ export enum ItemSearchIndexed {
   UpTo2MonthsAgo = '2months',
 }
 
-export interface ItemSearchOptions {
-  online?: boolean
-  indexed?: ItemSearchIndexed
-  leagueId?: string
-  language?: Language
-}
-
 export enum ItemSearchStatus {
   Online = 'online',//In person Trade Only
   Securable = 'securable',//Instant Buyout Only
   Available = 'available',//In Person Trade & Instant Buyout
   Any = 'any',
 }
+
+export interface ItemSearchOptions {
+  status?: ItemSearchStatus
+  indexed?: ItemSearchIndexed
+  leagueId?: string
+  language?: Language
+}
+

--- a/src/assets/i18n/english.json
+++ b/src/assets/i18n/english.json
@@ -145,6 +145,13 @@
         "empowerment": "Sentinel Empowerment",
         "enemies-empowered": "Sentinel Enemies Empowered"
       },
+      "trade-type": "Trade Type",
+      "status": {
+        "any": "Any",
+        "available": "Available",
+        "online": "Online",
+        "securable": "Instant Buyout"
+      },
       "ultimatum": "Ultimatum Challenge/Input/Output"
     },
     "searching": "Searching...",


### PR DESCRIPTION
## Description
For Issue #362 so we can evaluate items using Instant Buyout prices
- Replaced 'online' toggle with 'trade type' selection.
- Update related interfaces and services
- Changed default to instant buyout only

## Replication Steps
Evaluate something and observe its instant buyout only
<!-- Step by step instructions to replicate -->

## Screenshots/Video
Showing Evaluate Options

https://github.com/user-attachments/assets/e1a435b9-3a29-49bb-8a3f-e03f507602b9



Showing Evaluate Settings

https://github.com/user-attachments/assets/23597123-cca0-4730-8d98-ec1e89e93969


## How Has This Been Tested?

- [ ] ran `npm run ng:lint`
- [x] ran `npm run format`
   Yes, but it formatted more than just git changed so I aborted
- [x] ran `npm run ng:test` 
- [ ] added unit tests
- [x] manually tested

I ran npm run ng:test 88/90
ItemPricePredictionService should return items FAILED
UserSettingsFormComponent should create FAILED

But it also failed on master branch so idk
